### PR TITLE
CLI support for running experiments with various parameter combinations

### DIFF
--- a/src/ai/backend/client/cli/pretty.py
+++ b/src/ai/backend/client/cli/pretty.py
@@ -35,7 +35,7 @@ def format_pretty(msg, status=PrintStatus.NONE, colored=True):
     else:
         raise ValueError
     clear = '\x1b[0m' if colored else ''
-    return indicator + msg + clear
+    return indicator + textwrap.indent(msg, '  ')[1:] + clear
 
 
 format_info = functools.partial(format_pretty, status=PrintStatus.NONE)

--- a/src/ai/backend/client/cli/pretty.py
+++ b/src/ai/backend/client/cli/pretty.py
@@ -18,6 +18,31 @@ class PrintStatus(enum.Enum):
     WAITING = 1
     DONE = 2
     FAILED = 3
+    WARNING = 4
+
+
+def format_pretty(msg, status=PrintStatus.NONE, colored=True):
+    if status == PrintStatus.NONE:
+        indicator = '\x1b[96m\u2219' if colored else '\u2219'
+    elif status == PrintStatus.WAITING:
+        indicator = '\x1b[93m\u22EF' if colored else '\u22EF'
+    elif status == PrintStatus.DONE:
+        indicator = '\x1b[92m\u2714' if colored else '\u2714'
+    elif status == PrintStatus.FAILED:
+        indicator = '\x1b[91m\u2718' if colored else '\u2718'
+    elif status == PrintStatus.WARNING:
+        indicator = '\x1b[33m\u2219' if colored else '\u2219'
+    else:
+        raise ValueError
+    clear = '\x1b[0m' if colored else ''
+    return indicator + msg + clear
+
+
+format_info = functools.partial(format_pretty, status=PrintStatus.NONE)
+format_wait = functools.partial(format_pretty, status=PrintStatus.WAITING)
+format_done = functools.partial(format_pretty, status=PrintStatus.DONE)
+format_fail = functools.partial(format_pretty, status=PrintStatus.FAILED)
+format_warn = functools.partial(format_pretty, status=PrintStatus.WARNING)
 
 
 def print_pretty(msg, *, status=PrintStatus.NONE, file=None):
@@ -32,6 +57,8 @@ def print_pretty(msg, *, status=PrintStatus.NONE, file=None):
         indicator = '\x1b[92m\u2714' if file.isatty() else '\u2714'
     elif status == PrintStatus.FAILED:
         indicator = '\x1b[91m\u2718' if file.isatty() else '\u2718'
+    elif status == PrintStatus.WARNING:
+        indicator = '\x1b[33m\u2219' if file.isatty() else '\u2219'
     else:
         raise ValueError
     if file.isatty():
@@ -50,6 +77,7 @@ print_info = functools.partial(print_pretty, status=PrintStatus.NONE)
 print_wait = functools.partial(print_pretty, status=PrintStatus.WAITING)
 print_done = functools.partial(print_pretty, status=PrintStatus.DONE)
 print_fail = functools.partial(print_pretty, status=PrintStatus.FAILED)
+print_warn = functools.partial(print_pretty, status=PrintStatus.WARNING)
 
 
 class ProgressReportingReader(io.BufferedReader):

--- a/src/ai/backend/client/cli/run.py
+++ b/src/ai/backend/client/cli/run.py
@@ -105,7 +105,7 @@ async def exec_loop(stdout, stderr, kernel, mode, code, *, opts=None,
             vprint_done(msg)
         elif result['status'] == 'finished':
             exitCode = result.get('exitCode')
-            msg = 'Finished. (exit code = {0})'.format(exitCode)
+            msg = 'Execution finished. (exit code = {0})'.format(exitCode)
             if is_multi:
                 print(msg, file=stderr)
             vprint_done(msg)
@@ -162,7 +162,7 @@ def exec_loop_sync(stdout, stderr, kernel, mode, code, *, opts=None,
             code = ''
         elif result['status'] == 'finished':
             exitCode = result.get('exitCode')
-            vprint_done('Finished. (exit code = {0})'.format(exitCode),
+            vprint_done('Execution finished. (exit code = {0})'.format(exitCode),
                         file=stdout)
             break
         elif result['status'] == 'waiting-input':
@@ -407,8 +407,6 @@ def run(args):
                 await exec_loop(stdout, stderr, kernel, 'query', args.code,
                                 vprint_done=indexed_vprint_done,
                                 is_multi=is_multi)
-            if is_multi:
-                vprint_done('[{0}] Execution finished.'.format(idx))
         except BackendError as e:
             print_fail('[{0}] {1}'.format(idx, e))
             raise RuntimeError(e)

--- a/src/ai/backend/client/cli/run.py
+++ b/src/ai/backend/client/cli/run.py
@@ -90,11 +90,11 @@ async def exec_loop(stdout, stderr, kernel, mode, code, *, opts=None,
             print('--- end of generated files ---', file=stdout)
         if result['status'] == 'clean-finished':
             exitCode = result.get('exitCode')
-            msg = 'Cleanup finished. (exit code = {0})'.format(exitCode)
+            msg = 'Clean finished. (exit code = {0})'.format(exitCode)
             if is_multi:
                 print(msg, file=stderr)
             vprint_done(msg)
-        if result['status'] == 'build-finished':
+        elif result['status'] == 'build-finished':
             exitCode = result.get('exitCode')
             msg = 'Build finished. (exit code = {0})'.format(exitCode)
             if is_multi:
@@ -147,11 +147,11 @@ def exec_loop_sync(stdout, stderr, kernel, mode, code, *, opts=None,
             print('--- end of generated files ---', file=stdout)
         if result['status'] == 'clean-finished':
             exitCode = result.get('exitCode')
-            vprint_done('Cleanup finished. (exit code = {0}'.format(exitCode),
+            vprint_done('Clean finished. (exit code = {0}'.format(exitCode),
                         file=stdout)
             mode = 'continue'
             code = ''
-        if result['status'] == 'build-finished':
+        elif result['status'] == 'build-finished':
             exitCode = result.get('exitCode')
             vprint_done('Build finished. (exit code = {0})'.format(exitCode),
                         file=stdout)


### PR DESCRIPTION
* Extends `backend.ai run` command with new options: `--env-range`, `--build-range`, and `--exec-range` which accept "range expression" and may be specified multiple times.
  - Each range expression has a `key=range` structure and `range` part consists of a type prefix like `range:`, `linspace:`, or `case:`. After the type prefix, a comma separated list comes for the arguments to each range generator type.
  - The `run` command now generates all combinations of given range expressions and creates multiple sessions corresponding to them.
* When running multiple sessions, the console outputs are logged into a separate log directory (`~/.cache/backend.ai/client-logs` with their client-side session token and indices).
* Parallel execution is only supported in the websocket streaming mode. In the legacy mode, the sessions will be executed serially (one by one).
  - `--max-parallel` option to limit the number of maximum concurrent sessions is added but not implemented yet.