### PR TITLE
Hotfix and refactoring of proxy

### DIFF
--- a/src/ai/backend/client/__init__.py
+++ b/src/ai/backend/client/__init__.py
@@ -1,9 +1,9 @@
 from .exceptions import *  # noqa
-#from .session import *  # noqa
+from .session import *  # noqa
 
 __all__ = [
     exceptions.__all__,  # noqa
-    #session.__all__,  # noqa
+    session.__all__,  # noqa
 ]
 
 __version__ = '1.4.2'

--- a/src/ai/backend/client/__init__.py
+++ b/src/ai/backend/client/__init__.py
@@ -1,9 +1,9 @@
 from .exceptions import *  # noqa
-from .session import *  # noqa
+#from .session import *  # noqa
 
 __all__ = [
     exceptions.__all__,  # noqa
-    session.__all__,  # noqa
+    #session.__all__,  # noqa
 ]
 
 __version__ = '1.4.2'

--- a/src/ai/backend/client/admin.py
+++ b/src/ai/backend/client/admin.py
@@ -20,9 +20,9 @@ class BaseAdmin(BaseFunction):
             'query': query,
             'variables': variables if variables else {},
         }
-        resp = yield Request(cls._session,
-                             'POST', '/admin/graphql',
-                             gql_query)
+        rqst = Request(cls._session, 'POST', '/admin/graphql')
+        rqst.set_json(gql_query)
+        resp = yield rqst
         return resp.json()
 
     def __init_subclass__(cls):

--- a/src/ai/backend/client/admin.py
+++ b/src/ai/backend/client/admin.py
@@ -1,36 +1,26 @@
 from typing import Any, Mapping, Optional
 
-from .base import BaseFunction, SyncFunctionMixin
+from .base import api_function
 from .request import Request
 
 __all__ = (
-    'BaseAdmin',
     'Admin',
 )
 
 
-class BaseAdmin(BaseFunction):
+class Admin:
 
-    _session = None
+    session = None
 
+    @api_function
     @classmethod
-    def _query(cls, query: str,
-               variables: Optional[Mapping[str, Any]] = None):
+    async def query(cls, query: str,
+                    variables: Optional[Mapping[str, Any]] = None):
         gql_query = {
             'query': query,
             'variables': variables if variables else {},
         }
-        rqst = Request(cls._session, 'POST', '/admin/graphql')
+        rqst = Request(cls.session, 'POST', '/admin/graphql')
         rqst.set_json(gql_query)
-        resp = yield rqst
-        return resp.json()
-
-    def __init_subclass__(cls):
-        cls.query = cls._call_base_clsmethod(cls._query)
-
-
-class Admin(SyncFunctionMixin, BaseAdmin):
-    '''
-    Deprecated! Use ai.backend.client.Session instead.
-    '''
-    pass
+        async with rqst.fetch() as resp:
+            return await resp.ajson()

--- a/src/ai/backend/client/admin.py
+++ b/src/ai/backend/client/admin.py
@@ -23,4 +23,4 @@ class Admin:
         rqst = Request(cls.session, 'POST', '/admin/graphql')
         rqst.set_json(gql_query)
         async with rqst.fetch() as resp:
-            return await resp.ajson()
+            return await resp.json()

--- a/src/ai/backend/client/agent.py
+++ b/src/ai/backend/client/agent.py
@@ -42,5 +42,5 @@ class Agent:
             'variables': variables,
         })
         async with rqst.fetch() as resp:
-            data = await resp.ajson()
+            data = await resp.json()
             return data['agents']

--- a/src/ai/backend/client/agent.py
+++ b/src/ai/backend/client/agent.py
@@ -33,14 +33,15 @@ class BaseAgent(BaseFunction):
             '  }' \
             '}'
         q = q.replace('$fields', ' '.join(fields))
-        vars = {
+        variables = {
             'status': status,
         }
-        resp = yield Request(cls._session,
-            'POST', '/admin/graphql', {
-                'query': q,
-                'variables': vars,
-            })
+        rqst = Request(cls._session, 'POST', '/admin/graphql')
+        rqst.set_json({
+            'query': q,
+            'variables': variables,
+        })
+        resp = yield rqst
         data = resp.json()
         return data['agents']
 

--- a/src/ai/backend/client/auth.py
+++ b/src/ai/backend/client/auth.py
@@ -10,14 +10,16 @@ def generate_signature(method, version, endpoint,
     '''
     hash_type = hash_type
     hostname = endpoint._val.netloc  # FIXME: migrate to public API
-    if content_type.startswith('multipart/'):
+    if version >= 'v4.20181215':
         content = b''
+    else:
+        if content_type.startswith('multipart/'):
+            content = b''
     body_hash = hashlib.new(hash_type, content).hexdigest()
-    major_ver = version.split('.', 1)[0]
 
-    sign_str = '{}\n/{}/{}\n{}\nhost:{}\ncontent-type:{}\nx-backendai-version:{}\n{}'.format(  # noqa
+    sign_str = '{}\n/{}\n{}\nhost:{}\ncontent-type:{}\nx-backendai-version:{}\n{}'.format(  # noqa
         method.upper(),
-        major_ver, request_path,
+        request_path,
         date.isoformat(),
         hostname,
         content_type.lower(),

--- a/src/ai/backend/client/base.py
+++ b/src/ai/backend/client/base.py
@@ -1,136 +1,55 @@
-from abc import abstractmethod
 import functools
-import inspect
-
-from .compat import Py36Object
-from .exceptions import BackendAPIError
 
 __all__ = (
+    'APIFunctionMeta',
     'BaseFunction',
-    'SyncFunctionMixin',
-    'AsyncFunctionMixin',
+    'api_function',
 )
 
 
-class BaseFunction(Py36Object):
+def _wrap_method(cls, orig_name, meth):
 
-    '''
-    Implements the request creation and response handling logic,
-    while delegating the process of request sending to the subclasses
-    via the generator protocol.
-    '''
-
-    @abstractmethod
-    def _call_base_method(self, meth):
-        raise NotImplementedError
-
-    @classmethod
-    @abstractmethod
-    def _call_base_clsmethod(cls, meth):
-        raise NotImplementedError
-
-    @staticmethod
-    def _handle_response(resp, meth_gen):
-        if resp.status // 100 != 2:
-            raise BackendAPIError(resp.status, resp.reason, resp.text())
-        try:
-            meth_gen.send(resp)
-        except StopIteration as e:
-            return e.value
+    @functools.wraps(meth)
+    def _method(*args, **kwargs):
+        assert cls.session is not None, \
+               'You must use API wrapper functions via a Session object.'
+        # We need to keep the original attributes so that they could be correctly
+        # bound to the class/instance at runtime.
+        func = getattr(cls, orig_name)
+        coro = func(*args, **kwargs)
+        if hasattr(cls.session, 'worker_thread'):
+            return cls.session.worker_thread.execute(coro)
         else:
-            raise RuntimeError('Invalid state')
+            return coro
 
-    @staticmethod
-    async def _handle_response_async(resp, meth_gen):
-        if resp.status // 100 != 2:
-            raise BackendAPIError(resp.status, resp.reason, await resp.text())
-        try:
-            meth_gen.send(resp)
-        except StopIteration as e:
-            return e.value
-        else:
-            raise RuntimeError('Invalid state')
+    return _method
 
 
-class SyncFunctionMixin:
+def api_function(meth):
     '''
-    Synchronous request sender using requests.
+    Mark the wrapped method as the API function method.
     '''
-
-    @staticmethod
-    def _make_request(gen):
-        rqst = next(gen)
-        fetch_ctx = rqst.fetch()
-        return fetch_ctx
-
-    @classmethod
-    def _call_base_clsmethod(cls, meth):
-        assert inspect.ismethod(meth)
-
-        @classmethod
-        @functools.wraps(meth)
-        def _caller(cls, *args, **kwargs):
-            assert cls._session is not None, \
-                   'You must use API wrapper functions via a Session object.'
-            gen = meth(*args, **kwargs)
-            fetch_ctx = cls._make_request(gen)
-            with fetch_ctx as resp:
-                return cls._handle_response(resp, gen)
-
-        return _caller
-
-    def _call_base_method(self, meth):
-        assert inspect.ismethod(meth)
-
-        @functools.wraps(meth)
-        def _caller(*args, **kwargs):
-            assert type(self)._session is not None, \
-                   'You must use API wrapper functions via a Session object.'
-            gen = meth(*args, **kwargs)
-            fetch_ctx = self._make_request(gen)
-            with fetch_ctx as resp:
-                return self._handle_response(resp, gen)
-
-        return _caller
+    setattr(meth, '_backend_api', True)
+    return meth
 
 
-class AsyncFunctionMixin:
+class APIFunctionMeta(type):
     '''
-    Asynchronous request sender using aiohttp.
+    Converts all methods marked with :func:`api_function` into
+    session-aware methods.
     '''
 
-    @staticmethod
-    async def _make_request(gen):
-        rqst = next(gen)
-        fetch_ctx = rqst.fetch()
-        return fetch_ctx
+    def __init__(cls, name, bases, attrs, **kwargs):
+        assert 'session' in attrs, \
+               'An API function class must define the session attribute.'
+        super().__init__(name, bases, attrs)
+        for attr_name, attr_value in attrs.items():
+            if hasattr(attr_value, '_backend_api'):
+                orig_name = '_orig_' + attr_name
+                setattr(cls, orig_name, attr_value)
+                wrapped = _wrap_method(cls, orig_name, attr_value)
+                setattr(cls, attr_name, wrapped)
 
-    @classmethod
-    def _call_base_clsmethod(cls, meth):
-        assert inspect.ismethod(meth)
 
-        @classmethod
-        @functools.wraps(meth)
-        async def _caller(cls, *args, **kwargs):
-            assert cls._session is not None, \
-                   'You must use API wrapper functions via a Session object.'
-            gen = meth(*args, **kwargs)
-            fetch_ctx = await cls._make_request(gen)
-            async with fetch_ctx as resp:
-                return await cls._handle_response_async(resp, gen)
-
-        return _caller
-
-    def _call_base_method(self, meth):
-        assert inspect.ismethod(meth)
-
-        @functools.wraps(meth)
-        async def _caller(*args, **kwargs):
-            assert type(self)._session is not None, \
-                   'You must use API wrapper functions via a Session object.'
-            gen = meth(*args, **kwargs)
-            fetch_ctx = await self._make_request(gen)
-            async with fetch_ctx as resp:
-                return await self._handle_response_async(resp, gen)
-
-        return _caller
+class BaseFunction(metaclass=APIFunctionMeta):
+    session = None

--- a/src/ai/backend/client/base.py
+++ b/src/ai/backend/client/base.py
@@ -49,8 +49,8 @@ class SyncFunctionMixin:
     @staticmethod
     def _make_request(gen):
         rqst = next(gen)
-        resp = rqst.fetch()
-        return resp
+        fetch_ctx = rqst.fetch()
+        return fetch_ctx
 
     @classmethod
     def _call_base_clsmethod(cls, meth):
@@ -62,8 +62,9 @@ class SyncFunctionMixin:
             assert cls._session is not None, \
                    'You must use API wrapper functions via a Session object.'
             gen = meth(*args, **kwargs)
-            resp = cls._make_request(gen)
-            return cls._handle_response(resp, gen)
+            fetch_ctx = cls._make_request(gen)
+            with fetch_ctx as resp:
+                return cls._handle_response(resp, gen)
 
         return _caller
 
@@ -75,8 +76,9 @@ class SyncFunctionMixin:
             assert type(self)._session is not None, \
                    'You must use API wrapper functions via a Session object.'
             gen = meth(*args, **kwargs)
-            resp = self._make_request(gen)
-            return self._handle_response(resp, gen)
+            fetch_ctx = self._make_request(gen)
+            with fetch_ctx as resp:
+                return self._handle_response(resp, gen)
 
         return _caller
 
@@ -89,8 +91,8 @@ class AsyncFunctionMixin:
     @staticmethod
     async def _make_request(gen):
         rqst = next(gen)
-        resp = await rqst.afetch()
-        return resp
+        fetch_ctx = rqst.fetch()
+        return fetch_ctx
 
     @classmethod
     def _call_base_clsmethod(cls, meth):
@@ -102,8 +104,9 @@ class AsyncFunctionMixin:
             assert cls._session is not None, \
                    'You must use API wrapper functions via a Session object.'
             gen = meth(*args, **kwargs)
-            resp = await cls._make_request(gen)
-            return cls._handle_response(resp, gen)
+            fetch_ctx = await cls._make_request(gen)
+            async with fetch_ctx as resp:
+                return cls._handle_response(resp, gen)
 
         return _caller
 
@@ -115,7 +118,8 @@ class AsyncFunctionMixin:
             assert type(self)._session is not None, \
                    'You must use API wrapper functions via a Session object.'
             gen = meth(*args, **kwargs)
-            resp = await self._make_request(gen)
-            return self._handle_response(resp, gen)
+            fetch_ctx = await self._make_request(gen)
+            async with fetch_ctx as resp:
+                return self._handle_response(resp, gen)
 
         return _caller

--- a/src/ai/backend/client/cli/__init__.py
+++ b/src/ai/backend/client/cli/__init__.py
@@ -37,7 +37,7 @@ def register_command(*args, **kwargs):
 
         @functools.wraps(handler)
         def wrapped(args):
-            handler(args)
+            return handler(args)
 
         doc_summary = handler.__doc__.split('\n\n')[0]
         inner_parser = subparsers.add_parser(

--- a/src/ai/backend/client/cli/proxy.py
+++ b/src/ai/backend/client/cli/proxy.py
@@ -17,9 +17,9 @@ from ..session import AsyncSession
 
 
 class RawRequest(Request):
-    __slots__ = ['config', 'method', 'path',
+    __slots__ = ('config', 'method', 'path',
                  'date', 'headers',
-                 'content_type', '_content', 'reporthook']
+                 'content_type', '_content', 'reporthook')
 
     def __init__(self, session: AsyncSession,
                  method: str = 'GET',
@@ -60,13 +60,12 @@ class RawRequest(Request):
 
 
 class WebSocketProxy(Request):
-    __slots__ = ['conn', 'down_conn', 'upstream_buffer', 'upstream_buffer_task']
+    __slots__ = ('conn', 'down_conn', 'upstream_buffer', 'upstream_buffer_task')
 
     def __init__(self, session: AsyncSession,
                  path: str,
                  ws: web.WebSocketResponse):
-        self._session = session
-        super().__init__(self._session, "GET", path)
+        super().__init__(session, "GET", path)
         self.upstream_buffer = asyncio.PriorityQueue()
         self.down_conn = ws
         self.conn = None

--- a/src/ai/backend/client/compat.py
+++ b/src/ai/backend/client/compat.py
@@ -5,8 +5,6 @@ A compatibility module for backported codes from Python 3.6 standard library.
 import asyncio
 import binascii
 import os
-import sys
-import types
 
 
 def token_bytes(nbytes=None):
@@ -23,42 +21,6 @@ def token_hex(nbytes=None):
     Emulation of secrets.token_hex()
     '''
     return binascii.hexlify(token_bytes(nbytes)).decode('ascii')
-
-
-class Py36Type(type):
-    '''
-    Emulation of PEP-487.
-    (ref: https://www.python.org/dev/peps/pep-0487/)
-    '''
-
-    def __new__(cls, *args, **kwargs):
-        if len(args) != 3:
-            return super().__new__(cls, *args)
-        name, bases, ns = args
-        init = ns.get('__init_subclass__')
-        if isinstance(init, types.FunctionType):
-            ns['__init_subclass__'] = classmethod(init)
-        self = super().__new__(cls, name, bases, ns)
-        for k, v in self.__dict__.items():
-            func = getattr(v, '__set_name__', None)
-            if func is not None:
-                func(self, k)
-        if hasattr(super(self, self), '__init_subclass__'):
-            super(self, self).__init_subclass__(**kwargs)
-        return self
-
-    def __init__(self, name, bases, ns, **kwargs):
-        super().__init__(name, bases, ns)
-
-
-class Py36Object(object, metaclass=Py36Type):
-    @classmethod
-    def __init_subclass__(cls):
-        pass
-
-
-if sys.version_info >= (3, 6):
-    Py36Object = object  # noqa
 
 
 if hasattr(asyncio, 'get_running_loop'):

--- a/src/ai/backend/client/config.py
+++ b/src/ai/backend/client/config.py
@@ -39,7 +39,7 @@ class APIConfig:
 
     DEFAULTS = {
         'endpoint': 'https://api.backend.ai',
-        'version': 'v2.20170315',
+        'version': 'v4.20181215',
         'hash_type': 'sha256',
         'vfolder_mounts': [],
     }

--- a/src/ai/backend/client/kernel.py
+++ b/src/ai/backend/client/kernel.py
@@ -170,7 +170,6 @@ class Kernel:
     async def upload(self, files: Sequence[Union[str, Path]],
                      basedir: Union[str, Path] = None,
                      show_progress: bool = False):
-        attachments = []
         base_path = (Path.cwd() if basedir is None
                      else Path(basedir).resolve())
         files = [Path(file).resolve() for file in files]
@@ -182,6 +181,7 @@ class Kernel:
                         total=total_size,
                         disable=not show_progress)
         with tqdm_obj:
+            attachments = []
             for file_path in files:
                 try:
                     attachments.append(AttachedFile(

--- a/src/ai/backend/client/kernel.py
+++ b/src/ai/backend/client/kernel.py
@@ -9,18 +9,17 @@ import uuid
 import aiohttp.web
 from tqdm import tqdm
 
-from .base import BaseFunction, SyncFunctionMixin
+from .base import api_function
 from .exceptions import BackendClientError
-from .request import Request
+from .request import Request, AttachedFile
 from .cli.pretty import ProgressReportingReader
 
 __all__ = (
-    'BaseKernel',
     'Kernel',
 )
 
 
-class BaseKernel(BaseFunction):
+class Kernel:
 
     '''
     Implements the request creation and response handling logic,
@@ -28,15 +27,16 @@ class BaseKernel(BaseFunction):
     via the generator protocol.
     '''
 
-    _session = None
+    session = None
 
+    @api_function
     @classmethod
-    def _get_or_create(cls, lang: str,
-                       client_token: str = None,
-                       mounts: Iterable[str] = None,
-                       envs: Mapping[str, str] = None,
-                       resources: Mapping[str, int] = None,
-                       exec_timeout: int = 0) -> str:
+    async def get_or_create(cls, lang: str,
+                            client_token: str = None,
+                            mounts: Iterable[str] = None,
+                            envs: Mapping[str, str] = None,
+                            resources: Mapping[str, int] = None,
+                            exec_timeout: int = 0) -> str:
         if client_token:
             assert 4 <= len(client_token) <= 64, \
                    'Client session token should be 4 to 64 characters long.'
@@ -46,8 +46,9 @@ class BaseKernel(BaseFunction):
             mounts = []
         if resources is None:
             resources = {}
-        mounts.extend(cls._session.config.vfolder_mounts)
-        resp = yield Request(cls._session, 'POST', '/kernel/create', {
+        mounts.extend(cls.session.config.vfolder_mounts)
+        rqst = Request(cls.session, 'POST', '/kernel/create')
+        rqst.set_json({
             'lang': lang,
             'clientSessionToken': client_token,
             'config': {
@@ -58,29 +59,100 @@ class BaseKernel(BaseFunction):
                 'instanceGPUs': resources.get('gpu', None),
             },
         })
-        data = resp.json()
-        o = cls(data['kernelId'])  # type: ignore
-        o.created = data.get('created', True)     # True is for legacy
-        return o
+        async with rqst.fetch() as resp:
+            data = await resp.ajson()
+            o = cls(data['kernelId'])  # type: ignore
+            o.created = data.get('created', True)     # True is for legacy
+            return o
 
-    def _destroy(self):
-        resp = yield Request(self._session,
-                             'DELETE', '/kernel/{}'.format(self.kernel_id))
-        if resp.status == 200:
-            return resp.json()
+    def __init__(self, kernel_id: str):
+        self.kernel_id = kernel_id
 
-    def _restart(self):
-        yield Request(self._session,
-                      'PATCH', '/kernel/{}'.format(self.kernel_id))
+    @api_function
+    async def destroy(self):
+        rqst = Request(self.session,
+                       'DELETE', '/kernel/{}'.format(self.kernel_id))
+        async with rqst.fetch() as resp:
+            if resp.status == 200:
+                return await resp.ajson()
 
-    def _interrupt(self):
-        yield Request(self._session,
-                      'POST', '/kernel/{}/interrupt'.format(self.kernel_id))
+    @api_function
+    async def restart(self):
+        rqst = Request(self.session,
+                       'PATCH', '/kernel/{}'.format(self.kernel_id))
+        async with rqst.fetch():
+            pass
 
-    def _complete(self, code: str, opts: dict = None):
+    @api_function
+    async def interrupt(self):
+        rqst = Request(self.session,
+                       'POST', '/kernel/{}/interrupt'.format(self.kernel_id))
+        async with rqst.fetch():
+            pass
+
+    @api_function
+    async def complete(self, code: str, opts: dict = None):
         opts = {} if opts is None else opts
-        rqst = Request(self._session,
-            'POST', '/kernel/{}/complete'.format(self.kernel_id), {
+        rqst = Request(self.session,
+            'POST', '/kernel/{}/complete'.format(self.kernel_id))
+        rqst.set_json({
+            'code': code,
+            'options': {
+                'row': int(opts.get('row', 0)),
+                'col': int(opts.get('col', 0)),
+                'line': opts.get('line', ''),
+                'post': opts.get('post', ''),
+            },
+        })
+        async with rqst.fetch() as resp:
+            return await resp.ajson()
+
+    @api_function
+    async def get_info(self):
+        rqst = Request(self.session,
+                       'GET', '/kernel/{}'.format(self.kernel_id))
+        async with rqst.fetch() as resp:
+            return await resp.ajson()
+
+    @api_function
+    async def get_logs(self):
+        rqst = Request(self.session,
+                       'GET', '/kernel/{}/logs'.format(self.kernel_id))
+        async with rqst.fetch() as resp:
+            return await resp.ajson()
+
+    @api_function
+    async def execute(self, run_id: str = None,
+                      code: str = None,
+                      mode: str = 'query',
+                      opts: dict = None):
+        opts = opts if opts is not None else {}
+        if mode in {'query', 'continue', 'input'}:
+            assert code is not None  # but maybe empty due to continuation
+            rqst = Request(self.session,
+                'POST', '/kernel/{}'.format(self.kernel_id))
+            rqst.set_json({
+                'mode': mode,
+                'code': code,
+                'runId': run_id,
+            })
+        elif mode == 'batch':
+            rqst = Request(self.session,
+                'POST', '/kernel/{}'.format(self.kernel_id))
+            rqst.set_json({
+                'mode': mode,
+                'code': code,
+                'runId': run_id,
+                'options': {
+                    'build': opts.get('build', None),
+                    'buildLog': bool(opts.get('buildLog', False)),
+                    'exec': opts.get('exec', None),
+                },
+            })
+        elif mode == 'complete':
+            rqst = Request(self.session,
+                'POST', '/kernel/{}/complete'.format(self.kernel_id))
+            rqst.set_json({
                 'code': code,
                 'options': {
                     'row': int(opts.get('row', 0)),
@@ -89,64 +161,16 @@ class BaseKernel(BaseFunction):
                     'post': opts.get('post', ''),
                 },
             })
-        resp = yield rqst
-        return resp.json()
-
-    def _get_info(self):
-        resp = yield Request(self._session,
-                             'GET', '/kernel/{}'.format(self.kernel_id))
-        return resp.json()
-
-    def _get_logs(self):
-        resp = yield Request(self._session,
-                             'GET', '/kernel/{}/logs'.format(self.kernel_id))
-        return resp.json()
-
-    def _execute(self, run_id: str = None,
-                 code: str = None,
-                 mode: str = 'query',
-                 opts: dict = None):
-        opts = {} if opts is None else opts
-        if mode in {'query', 'continue', 'input'}:
-            assert code is not None  # but maybe empty due to continuation
-            rqst = Request(self._session,
-                'POST', '/kernel/{}'.format(self.kernel_id), {
-                    'mode': mode,
-                    'code': code,
-                    'runId': run_id,
-                })
-        elif mode == 'batch':
-            rqst = Request(self._session,
-                'POST', '/kernel/{}'.format(self.kernel_id), {
-                    'mode': mode,
-                    'code': code,
-                    'runId': run_id,
-                    'options': {
-                        'build': opts.get('build', None),
-                        'buildLog': bool(opts.get('buildLog', False)),
-                        'exec': opts.get('exec', None),
-                    },
-                })
-        elif mode == 'complete':
-            rqst = Request(self._session,
-                'POST', '/kernel/{}/complete'.format(self.kernel_id), {
-                    'code': code,
-                    'options': {
-                        'row': int(opts.get('row', 0)),
-                        'col': int(opts.get('col', 0)),
-                        'line': opts.get('line', ''),
-                        'post': opts.get('post', ''),
-                    },
-                })
         else:
             raise BackendClientError('Invalid execution mode: {0}'.format(mode))
-        resp = yield rqst
-        return resp.json()['result']
+        async with rqst.fetch() as resp:
+            return (await resp.ajson())['result']
 
-    def _upload(self, files: Sequence[Union[str, Path]],
-               basedir: Union[str, Path] = None,
-               show_progress: bool = False):
-        fields = []
+    @api_function
+    async def upload(self, files: Sequence[Union[str, Path]],
+                     basedir: Union[str, Path] = None,
+                     show_progress: bool = False):
+        attachments = []
         base_path = (Path.cwd() if basedir is None
                      else Path(basedir).resolve())
         files = [Path(file).resolve() for file in files]
@@ -160,100 +184,81 @@ class BaseKernel(BaseFunction):
         with tqdm_obj:
             for file_path in files:
                 try:
-                    fields.append(aiohttp.web.FileField(
-                        'src',
+                    attachments.append(AttachedFile(
                         str(file_path.relative_to(base_path)),
                         ProgressReportingReader(str(file_path),
                                                 tqdm_instance=tqdm_obj),
                         'application/octet-stream',
-                        None
                     ))
                 except ValueError:
                     msg = 'File "{0}" is outside of the base directory "{1}".' \
                           .format(file_path, base_path)
                     raise ValueError(msg) from None
 
-            rqst = Request(self._session,
+            rqst = Request(self.session,
                            'POST', '/kernel/{}/upload'.format(self.kernel_id))
-            rqst.content = fields
-            resp = yield rqst
-        return resp
+            rqst.attach_files(attachments)
+            async with rqst.fetch() as resp:
+                return resp
 
-    def _download(self, files: Sequence[Union[str, Path]],
-                  show_progress: bool = False):
-        resp = yield Request(self._session,
-            'GET', '/kernel/{}/download'.format(self.kernel_id), {
-                'files': files,
-            })
-        chunk_size = 1 * 1024
-        tqdm_obj = tqdm(desc='Downloading files',
-                        unit='bytes', unit_scale=True,
-                        total=resp.stream_reader.total_bytes,
-                        disable=not show_progress)
-        with tqdm_obj as pbar:
-            fp = None
-            while True:
-                chunk = resp.read(chunk_size)
-                if not chunk:
-                    break
-                pbar.update(len(chunk))
-                # TODO: more elegant parsing of multipart response?
-                for part in chunk.split(b'\r\n'):
-                    if part.startswith(b'--'):
-                        if fp:
-                            fp.close()
-                            with tarfile.open(fp.name) as tarf:
-                                tarf.extractall()
-                            os.unlink(fp.name)
-                        fp = tempfile.NamedTemporaryFile(suffix='.tar', delete=False)
-                    elif part.startswith(b'Content-') or part == b'':
-                        continue
-                    else:
-                        fp.write(part)
-            if fp:
-                fp.close()
-                os.unlink(fp.name)
-        return resp
+    @api_function
+    async def download(self, files: Sequence[Union[str, Path]],
+                       show_progress: bool = False):
+        rqst = Request(self.session,
+                       'GET', '/kernel/{}/download'.format(self.kernel_id))
+        rqst.set_json({
+            'files': files,
+        })
+        async with rqst.fetch() as resp:
+            chunk_size = 1 * 1024
+            tqdm_obj = tqdm(desc='Downloading files',
+                            unit='bytes', unit_scale=True,
+                            total=resp.raw_response.stream_reader.total_bytes,
+                            disable=not show_progress)
+            with tqdm_obj as pbar:
+                fp = None
+                while True:
+                    chunk = await resp.aread(chunk_size)
+                    if not chunk:
+                        break
+                    pbar.update(len(chunk))
+                    # TODO: more elegant parsing of multipart response?
+                    for part in chunk.split(b'\r\n'):
+                        if part.startswith(b'--'):
+                            if fp:
+                                fp.close()
+                                with tarfile.open(fp.name) as tarf:
+                                    tarf.extractall()
+                                os.unlink(fp.name)
+                            fp = tempfile.NamedTemporaryFile(suffix='.tar',
+                                                             delete=False)
+                        elif part.startswith(b'Content-') or part == b'':
+                            continue
+                        else:
+                            fp.write(part)
+                if fp:
+                    fp.close()
+                    os.unlink(fp.name)
+            return resp
 
-    def _list_files(self, path: Union[str, Path] = '.'):
-        resp = yield Request(self._session,
+    @api_function
+    async def list_files(self, path: Union[str, Path] = '.'):
+        rqst = Request(self.session,
             'GET', '/kernel/{}/files'.format(self.kernel_id), {
                 'path': path,
             })
-        return resp.json()
+        async with rqst.fetch() as resp:
+            return await resp.ajson()
 
     # only supported in AsyncKernel
     async def stream_pty(self):
-        request = Request(self._session,
+        request = Request(self.session,
                           'GET', '/stream/kernel/{}/pty'.format(self.kernel_id))
         try:
             _, ws = await request.connect_websocket()
         except aiohttp.ClientResponseError as e:
             raise BackendClientError(e.code, e.message)
         return StreamPty(self.kernel_id, ws)
-
-    def __init__(self, kernel_id: str) -> None:
-        self.kernel_id = kernel_id
-        self.destroy   = self._call_base_method(self._destroy)
-        self.restart   = self._call_base_method(self._restart)
-        self.interrupt = self._call_base_method(self._interrupt)
-        self.complete  = self._call_base_method(self._complete)
-        self.get_info  = self._call_base_method(self._get_info)
-        self.get_logs  = self._call_base_method(self._get_logs)
-        self.execute   = self._call_base_method(self._execute)
-        self.upload    = self._call_base_method(self._upload)
-        self.download  = self._call_base_method(self._download)
-        self.list_files = self._call_base_method(self._list_files)
-
-    def __init_subclass__(cls):
-        cls.get_or_create = cls._call_base_clsmethod(cls._get_or_create)
-
-
-class Kernel(SyncFunctionMixin, BaseKernel):
-    '''
-    Deprecated! Use ai.backend.client.Session instead.
-    '''
-    pass
 
 
 class StreamPty:

--- a/src/ai/backend/client/kernel.py
+++ b/src/ai/backend/client/kernel.py
@@ -60,7 +60,7 @@ class Kernel:
             },
         })
         async with rqst.fetch() as resp:
-            data = await resp.ajson()
+            data = await resp.json()
             o = cls(data['kernelId'])  # type: ignore
             o.created = data.get('created', True)     # True is for legacy
             return o
@@ -74,7 +74,7 @@ class Kernel:
                        'DELETE', '/kernel/{}'.format(self.kernel_id))
         async with rqst.fetch() as resp:
             if resp.status == 200:
-                return await resp.ajson()
+                return await resp.json()
 
     @api_function
     async def restart(self):
@@ -105,21 +105,21 @@ class Kernel:
             },
         })
         async with rqst.fetch() as resp:
-            return await resp.ajson()
+            return await resp.json()
 
     @api_function
     async def get_info(self):
         rqst = Request(self.session,
                        'GET', '/kernel/{}'.format(self.kernel_id))
         async with rqst.fetch() as resp:
-            return await resp.ajson()
+            return await resp.json()
 
     @api_function
     async def get_logs(self):
         rqst = Request(self.session,
                        'GET', '/kernel/{}/logs'.format(self.kernel_id))
         async with rqst.fetch() as resp:
-            return await resp.ajson()
+            return await resp.json()
 
     @api_function
     async def execute(self, run_id: str = None,
@@ -164,7 +164,7 @@ class Kernel:
         else:
             raise BackendClientError('Invalid execution mode: {0}'.format(mode))
         async with rqst.fetch() as resp:
-            return (await resp.ajson())['result']
+            return (await resp.json())['result']
 
     @api_function
     async def upload(self, files: Sequence[Union[str, Path]],
@@ -248,7 +248,7 @@ class Kernel:
                 'path': path,
             })
         async with rqst.fetch() as resp:
-            return await resp.ajson()
+            return await resp.json()
 
     # only supported in AsyncKernel
     async def stream_pty(self):

--- a/src/ai/backend/client/keypair.py
+++ b/src/ai/backend/client/keypair.py
@@ -1,26 +1,26 @@
 from typing import Iterable, Union
 
-from .base import BaseFunction, SyncFunctionMixin
+from .base import api_function
 from .request import Request
 
 __all__ = (
-    'BaseKeyPair',
     'KeyPair',
 )
 
 
-class BaseKeyPair(BaseFunction):
+class KeyPair:
 
-    _session = None
+    session = None
 
+    @api_function
     @classmethod
-    def _create(cls, user_id: Union[int, str],
-                is_active: bool = True,
-                is_admin: bool = False,
-                resource_policy: str = None,
-                rate_limit: int = None,
-                concurrency_limit: int = None,
-                fields: Iterable[str] = None):
+    async def create(cls, user_id: Union[int, str],
+                     is_active: bool = True,
+                     is_admin: bool = False,
+                     resource_policy: str = None,
+                     rate_limit: int = None,
+                     concurrency_limit: int = None,
+                     fields: Iterable[str] = None):
         if fields is None:
             fields = ('access_key', 'secret_key')
         uid_type = 'Int!' if isinstance(user_id, int) else 'String!'
@@ -40,19 +40,20 @@ class BaseKeyPair(BaseFunction):
                 'concurrency_limit': concurrency_limit,
             },
         }
-        rqst = Request(cls._session, 'POST', '/admin/graphql')
+        rqst = Request(cls.session, 'POST', '/admin/graphql')
         rqst.set_json({
             'query': q,
             'variables': variables,
         })
-        resp = yield rqst
-        data = resp.json()
-        return data['create_keypair']
+        async with rqst.fetch() as resp:
+            data = await resp.ajson()
+            return data['create_keypair']
 
+    @api_function
     @classmethod
-    def _list(cls, user_id: Union[int, str],
-              is_active: bool = None,
-              fields: Iterable[str] = None):
+    async def list(cls, user_id: Union[int, str],
+                   is_active: bool = None,
+                   fields: Iterable[str] = None):
         if fields is None:
             fields = (
                 'access_key', 'secret_key',
@@ -69,30 +70,21 @@ class BaseKeyPair(BaseFunction):
             'user_id': user_id,
             'is_active': is_active,
         }
-        rqst = Request(cls._session, 'POST', '/admin/graphql')
+        rqst = Request(cls.session, 'POST', '/admin/graphql')
         rqst.set_json({
             'query': q,
             'variables': variables,
         })
-        resp = yield rqst
-        data = resp.json()
-        return data['keypairs']
+        async with rqst.fetch() as resp:
+            data = await resp.ajson()
+            return data['keypairs']
 
+    @api_function
     @classmethod
-    def activate(cls, access_key: str):
+    async def activate(cls, access_key: str):
         raise NotImplementedError
 
+    @api_function
     @classmethod
-    def deactivate(cls, access_key: str):
+    async def deactivate(cls, access_key: str):
         raise NotImplementedError
-
-    def __init_subclass__(cls):
-        cls.create = cls._call_base_clsmethod(cls._create)
-        cls.list = cls._call_base_clsmethod(cls._list)
-
-
-class KeyPair(SyncFunctionMixin, BaseKeyPair):
-    '''
-    Deprecated! Use ai.backend.client.Session instead.
-    '''
-    pass

--- a/src/ai/backend/client/keypair.py
+++ b/src/ai/backend/client/keypair.py
@@ -46,7 +46,7 @@ class KeyPair:
             'variables': variables,
         })
         async with rqst.fetch() as resp:
-            data = await resp.ajson()
+            data = await resp.json()
             return data['create_keypair']
 
     @api_function
@@ -76,7 +76,7 @@ class KeyPair:
             'variables': variables,
         })
         async with rqst.fetch() as resp:
-            data = await resp.ajson()
+            data = await resp.json()
             return data['keypairs']
 
     @api_function

--- a/src/ai/backend/client/keypair.py
+++ b/src/ai/backend/client/keypair.py
@@ -30,7 +30,7 @@ class BaseKeyPair(BaseFunction):
             '  }' \
             '}'
         q = q.replace('$fields', ' '.join(fields))
-        vars = {
+        variables = {
             'user_id': user_id,
             'input': {
                 'is_active': is_active,
@@ -40,10 +40,12 @@ class BaseKeyPair(BaseFunction):
                 'concurrency_limit': concurrency_limit,
             },
         }
-        resp = yield Request(cls._session, 'POST', '/admin/graphql', {
+        rqst = Request(cls._session, 'POST', '/admin/graphql')
+        rqst.set_json({
             'query': q,
-            'variables': vars,
+            'variables': variables,
         })
+        resp = yield rqst
         data = resp.json()
         return data['create_keypair']
 
@@ -63,14 +65,16 @@ class BaseKeyPair(BaseFunction):
             '  }' \
             '}'
         q = q.replace('$fields', ' '.join(fields))
-        vars = {
+        variables = {
             'user_id': user_id,
             'is_active': is_active,
         }
-        resp = yield Request(cls._session, 'POST', '/admin/graphql', {
+        rqst = Request(cls._session, 'POST', '/admin/graphql')
+        rqst.set_json({
             'query': q,
-            'variables': vars,
+            'variables': variables,
         })
+        resp = yield rqst
         data = resp.json()
         return data['keypairs']
 

--- a/src/ai/backend/client/request.py
+++ b/src/ai/backend/client/request.py
@@ -206,6 +206,9 @@ class Request:
                                filename=f.filename,
                                content_type=f.content_type)
             assert data.is_multipart
+            # Let aiohttp fill up the content-type header including
+            # multipart boundaries.
+            self.headers.pop('Content-Type')
             return data
         else:
             return self._content

--- a/src/ai/backend/client/request.py
+++ b/src/ai/backend/client/request.py
@@ -184,15 +184,9 @@ class Request:
             secret_key = self.config.secret_key
         if hash_type is None:
             hash_type = self.config.hash_type
-        if self.config.version >= 'v4.20181215':
-            # new APIs don't use payload to calculate signatures
-            payload = b''
-        else:
-            # assuming that the content object provides bytes serialization
-            payload = bytes(self._content)
         hdrs, _ = generate_signature(
             self.method, self.config.version, self.config.endpoint,
-            self.date, self.path, self.content_type, payload,
+            self.date, self.path, self.content_type, self._content,
             access_key, secret_key, hash_type)
         self.headers.update(hdrs)
 

--- a/src/ai/backend/client/session.py
+++ b/src/ai/backend/client/session.py
@@ -5,7 +5,6 @@ import queue
 
 import aiohttp
 
-from .base import SyncFunctionMixin, AsyncFunctionMixin
 from .config import APIConfig, get_config
 
 
@@ -103,25 +102,31 @@ class Session(BaseSession):
 
         self.aiohttp_session = self.worker_thread.execute(_create_aiohttp_session())
 
-        from .admin import BaseAdmin
-        from .agent import BaseAgent
-        from .kernel import BaseKernel
-        from .keypair import BaseKeyPair
-        from .vfolder import BaseVFolder
-        self.Admin = type('Admin', (SyncFunctionMixin, BaseAdmin), {
-            '_session': self,
+        from .base import BaseFunction
+        from .admin import Admin
+        from .agent import Agent
+        from .kernel import Kernel
+        from .keypair import KeyPair
+        from .vfolder import VFolder
+        self.Admin = type('Admin', (BaseFunction, ), {
+            **Admin.__dict__,
+            'session': self,
         })
-        self.Agent = type('Agent', (SyncFunctionMixin, BaseAgent), {
-            '_session': self,
+        self.Agent = type('Agent', (BaseFunction, ), {
+            **Agent.__dict__,
+            'session': self,
         })
-        self.Kernel = type('Kernel', (SyncFunctionMixin, BaseKernel), {
-            '_session': self,
+        self.Kernel = type('Kernel', (BaseFunction, ), {
+            **Kernel.__dict__,
+            'session': self,
         })
-        self.KeyPair = type('KeyPair', (SyncFunctionMixin, BaseKeyPair), {
-            '_session': self,
+        self.KeyPair = type('KeyPair', (BaseFunction, ), {
+            **KeyPair.__dict__,
+            'session': self,
         })
-        self.VFolder = type('VFolder', (SyncFunctionMixin, BaseVFolder), {
-            '_session': self,
+        self.VFolder = type('VFolder', (BaseFunction, ), {
+            **VFolder.__dict__,
+            'session': self,
         })
 
     def close(self):
@@ -142,6 +147,7 @@ class Session(BaseSession):
 
     def __exit__(self, exc_type, exc_obj, exc_tb):
         self.close()
+        return False
 
 
 class AsyncSession(BaseSession):
@@ -163,25 +169,31 @@ class AsyncSession(BaseSession):
 
         self.aiohttp_session = aiohttp.ClientSession()
 
-        from .admin import BaseAdmin
-        from .agent import BaseAgent
-        from .kernel import BaseKernel
-        from .keypair import BaseKeyPair
-        from .vfolder import BaseVFolder
-        self.Admin = type('Admin', (AsyncFunctionMixin, BaseAdmin), {
-            '_session': self,
+        from .base import BaseFunction
+        from .admin import Admin
+        from .agent import Agent
+        from .kernel import Kernel
+        from .keypair import KeyPair
+        from .vfolder import VFolder
+        self.Admin = type('Admin', (BaseFunction, ), {
+            **Admin.__dict__,
+            'session': self,
         })
-        self.Agent = type('Agent', (AsyncFunctionMixin, BaseAgent), {
-            '_session': self,
+        self.Agent = type('Agent', (BaseFunction, ), {
+            **Agent.__dict__,
+            'session': self,
         })
-        self.Kernel = type('Kernel', (AsyncFunctionMixin, BaseKernel), {
-            '_session': self,
+        self.Kernel = type('Kernel', (BaseFunction, ), {
+            **Kernel.__dict__,
+            'session': self,
         })
-        self.KeyPair = type('KeyPair', (AsyncFunctionMixin, BaseKeyPair), {
-            '_session': self,
+        self.KeyPair = type('KeyPair', (BaseFunction, ), {
+            **KeyPair.__dict__,
+            'session': self,
         })
-        self.VFolder = type('VFolder', (AsyncFunctionMixin, BaseVFolder), {
-            '_session': self,
+        self.VFolder = type('VFolder', (BaseFunction, ), {
+            **VFolder.__dict__,
+            'session': self,
         })
 
     async def close(self):
@@ -196,3 +208,4 @@ class AsyncSession(BaseSession):
 
     async def __aexit__(self, exc_type, exc_obj, exc_tb):
         await self.close()
+        return False

--- a/src/ai/backend/client/vfolder.py
+++ b/src/ai/backend/client/vfolder.py
@@ -32,7 +32,7 @@ class VFolder:
             'name': name,
         })
         async with rqst.fetch() as resp:
-            return await resp.ajson()
+            return await resp.json()
 
     def __init__(self, name: str):
         assert _rx_slug.search(name) is not None, 'Invalid vfolder name format'
@@ -43,20 +43,20 @@ class VFolder:
     async def list(cls):
         rqst = Request(cls.session, 'GET', '/folders/')
         async with rqst.fetch() as resp:
-            return await resp.ajson()
+            return await resp.json()
 
     @api_function
     async def info(self):
         rqst = Request(self.session, 'GET', '/folders/{0}'.format(self.name))
         async with rqst.fetch() as resp:
-            return await resp.ajson()
+            return await resp.json()
 
     @api_function
     async def delete(self):
         rqst = Request(self.session, 'DELETE', '/folders/{0}'.format(self.name))
         async with rqst.fetch() as resp:
             if resp.status == 200:
-                return await resp.ajson()
+                return await resp.json()
 
     @api_function
     async def upload(self, files: Sequence[Union[str, Path]],
@@ -177,7 +177,7 @@ class VFolder:
             'path': path,
         })
         async with rqst.fetch() as resp:
-            return await resp.ajson()
+            return await resp.json()
 
     @api_function
     async def invite(self, perm: str, emails: Sequence[str]):
@@ -186,14 +186,14 @@ class VFolder:
             'perm': perm, 'user_ids': emails,
         })
         async with rqst.fetch() as resp:
-            return await resp.ajson()
+            return await resp.json()
 
     @api_function
     @classmethod
     async def invitations(cls):
         rqst = Request(cls.session, 'GET', '/folders/invitations/list')
         async with rqst.fetch() as resp:
-            return await resp.ajson()
+            return await resp.json()
 
     @api_function
     @classmethod
@@ -201,7 +201,7 @@ class VFolder:
         rqst = Request(cls.session, 'POST', '/folders/invitations/accept')
         rqst.set_json({'inv_id': inv_id, 'inv_ak': inv_ak})
         async with rqst.fetch() as resp:
-            return await resp.ajson()
+            return await resp.json()
 
     @api_function
     @classmethod
@@ -209,4 +209,4 @@ class VFolder:
         rqst = Request(cls.session, 'DELETE', '/folders/invitations/delete')
         rqst.set_json({'inv_id': inv_id})
         async with rqst.fetch() as resp:
-            return await resp.ajson()
+            return await resp.json()

--- a/src/ai/backend/client/vfolder.py
+++ b/src/ai/backend/client/vfolder.py
@@ -30,9 +30,11 @@ class BaseVFolder(BaseFunction):
     @classmethod
     def _create(cls, name: str):
         assert _rx_slug.search(name) is not None
-        resp = yield Request(cls._session, 'POST', '/folders/', {
+        rqst = Request(cls._session, 'POST', '/folders/')
+        rqst.set_json({
             'name': name,
         })
+        resp = yield rqst
         return resp.json()
 
     @classmethod
@@ -178,17 +180,19 @@ class BaseVFolder(BaseFunction):
         self._session.worker_thread.execute(_stream_download())
 
     def _list_files(self, path: Union[str, Path] = '.'):
-        resp = yield Request(self._session,
-            'GET', '/folders/{}/files'.format(self.name), {
-                'path': path,
-            })
+        rqst = Request(self._session, 'GET', '/folders/{}/files'.format(self.name))
+        rqst.set_json({
+            'path': path,
+        })
+        resp = yield rqst
         return resp.json()
 
     def _invite(self, perm: str, emails: Sequence[str]):
-        resp = yield Request(self._session,
-            'POST', '/folders/{}/invite'.format(self.name), {
-                'perm': perm, 'user_ids': emails,
-            })
+        rqst = Request(self._session, 'POST', '/folders/{}/invite'.format(self.name))
+        rqst.set_json({
+            'perm': perm, 'user_ids': emails,
+        })
+        resp = yield rqst
         return resp.json()
 
     @classmethod
@@ -198,14 +202,16 @@ class BaseVFolder(BaseFunction):
 
     @classmethod
     def _accept_invitation(cls, inv_id: str, inv_ak: str):
-        resp = yield Request(cls._session, 'POST', '/folders/invitations/accept',
-                             {'inv_id': inv_id, 'inv_ak': inv_ak})
+        rqst = Request(cls._session, 'POST', '/folders/invitations/accept')
+        rqst.set_json({'inv_id': inv_id, 'inv_ak': inv_ak})
+        resp = yield rqst
         return resp.json()
 
     @classmethod
     def _delete_invitation(cls, inv_id: str):
-        resp = yield Request(cls._session, 'DELETE', '/folders/invitations/delete',
-                             {'inv_id': inv_id})
+        rqst = Request(cls._session, 'DELETE', '/folders/invitations/delete')
+        rqst.set_json({'inv_id': inv_id})
+        resp = yield rqst
         return resp.json()
 
     def __init__(self, name: str):

--- a/src/ai/backend/client/vfolder.py
+++ b/src/ai/backend/client/vfolder.py
@@ -27,7 +27,7 @@ class VFolder:
     @classmethod
     async def create(cls, name: str):
         assert _rx_slug.search(name) is not None
-        rqst = Request(cls.session, 'POST', '/folders/')
+        rqst = Request(cls.session, 'POST', '/folders')
         rqst.set_json({
             'name': name,
         })
@@ -41,7 +41,7 @@ class VFolder:
     @api_function
     @classmethod
     async def list(cls):
-        rqst = Request(cls.session, 'GET', '/folders/')
+        rqst = Request(cls.session, 'GET', '/folders')
         async with rqst.fetch() as resp:
             return await resp.json()
 

--- a/src/ai/backend/client/vfolder.py
+++ b/src/ai/backend/client/vfolder.py
@@ -62,7 +62,6 @@ class VFolder:
     async def upload(self, files: Sequence[Union[str, Path]],
                      basedir: Union[str, Path] = None,
                      show_progress: bool = False):
-        files = []
         base_path = (Path.cwd() if basedir is None
                      else Path(basedir).resolve())
         files = [Path(file).resolve() for file in files]
@@ -74,9 +73,10 @@ class VFolder:
                         total=total_size,
                         disable=not show_progress)
         with tqdm_obj:
+            attachments = []
             for file_path in files:
                 try:
-                    files.append(AttachedFile(
+                    attachments.append(AttachedFile(
                         str(file_path.relative_to(base_path)),
                         ProgressReportingReader(str(file_path),
                                                 tqdm_instance=tqdm_obj),
@@ -89,7 +89,7 @@ class VFolder:
 
             rqst = Request(self.session,
                            'POST', '/folders/{}/upload'.format(self.name))
-            rqst.attach_files(files)
+            rqst.attach_files(attachments)
             async with rqst.fetch() as resp:
                 return resp
 

--- a/src/ai/backend/client/vfolder.py
+++ b/src/ai/backend/client/vfolder.py
@@ -1,66 +1,68 @@
 import asyncio
-from datetime import datetime
 from pathlib import Path
 import re
 from typing import Sequence, Union
 import zlib
 
 import aiohttp
-from async_timeout import timeout as _timeout
-from dateutil.tz import tzutc
 from tqdm import tqdm
 
-from .base import BaseFunction, SyncFunctionMixin
+from .base import api_function
 from .exceptions import BackendAPIError, BackendClientError
-from .request import Request
+from .request import Request, AttachedFile
 from .cli.pretty import ProgressReportingReader
 
 __all__ = (
-    'BaseVFolder',
     'VFolder',
 )
 
 _rx_slug = re.compile(r'^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$')
 
 
-class BaseVFolder(BaseFunction):
+class VFolder:
 
-    _session = None
+    session = None
 
+    @api_function
     @classmethod
-    def _create(cls, name: str):
+    async def create(cls, name: str):
         assert _rx_slug.search(name) is not None
-        rqst = Request(cls._session, 'POST', '/folders/')
+        rqst = Request(cls.session, 'POST', '/folders/')
         rqst.set_json({
             'name': name,
         })
-        resp = yield rqst
-        return resp.json()
+        async with rqst.fetch() as resp:
+            return await resp.ajson()
 
+    def __init__(self, name: str):
+        assert _rx_slug.search(name) is not None, 'Invalid vfolder name format'
+        self.name = name
+
+    @api_function
     @classmethod
-    def _list(cls):
-        resp = yield Request(cls._session, 'GET', '/folders/')
-        return resp.json()
+    async def list(cls):
+        rqst = Request(cls.session, 'GET', '/folders/')
+        async with rqst.fetch() as resp:
+            return await resp.ajson()
 
-    @classmethod
-    def _get(cls, name: str):
-        return cls(name)
+    @api_function
+    async def info(self):
+        rqst = Request(self.session, 'GET', '/folders/{0}'.format(self.name))
+        async with rqst.fetch() as resp:
+            return await resp.ajson()
 
-    def _info(self):
-        resp = yield Request(self._session,
-                             'GET', '/folders/{0}'.format(self.name))
-        return resp.json()
+    @api_function
+    async def delete(self):
+        rqst = Request(self.session, 'DELETE', '/folders/{0}'.format(self.name))
+        async with rqst.fetch() as resp:
+            if resp.status == 200:
+                return await resp.ajson()
 
-    def _delete(self):
-        resp = yield Request(self._session,
-                             'DELETE', '/folders/{0}'.format(self.name))
-        if resp.status == 200:
-            return resp.json()
-
-    def _upload(self, files: Sequence[Union[str, Path]],
-               basedir: Union[str, Path] = None,
-               show_progress: bool = False):
-        fields = []
+    @api_function
+    async def upload(self, files: Sequence[Union[str, Path]],
+                     basedir: Union[str, Path] = None,
+                     show_progress: bool = False):
+        files = []
         base_path = (Path.cwd() if basedir is None
                      else Path(basedir).resolve())
         files = [Path(file).resolve() for file in files]
@@ -74,173 +76,137 @@ class BaseVFolder(BaseFunction):
         with tqdm_obj:
             for file_path in files:
                 try:
-                    fields.append(aiohttp.web.FileField(
-                        'src',
+                    files.append(AttachedFile(
                         str(file_path.relative_to(base_path)),
                         ProgressReportingReader(str(file_path),
                                                 tqdm_instance=tqdm_obj),
                         'application/octet-stream',
-                        None
                     ))
                 except ValueError:
                     msg = 'File "{0}" is outside of the base directory "{1}".' \
                           .format(file_path, base_path)
                     raise ValueError(msg) from None
 
-            rqst = Request(self._session,
+            rqst = Request(self.session,
                            'POST', '/folders/{}/upload'.format(self.name))
-            rqst.content = fields
-            resp = yield rqst
-        return resp
+            rqst.attach_files(files)
+            async with rqst.fetch() as resp:
+                return resp
 
-    def _mkdir(self,
-                      path: Union[str, Path]):
-        resp = yield Request(
-            self._session,
-            'POST', '/folders/{}/mkdir'.format(self.name),
-            {
-                'path': path,
-            })
-        return resp
-
-    def _delete_files(self,
-                      files: Sequence[Union[str, Path]],
-                      recursive: bool = False):
-        resp = yield Request(
-            self._session,
-            'DELETE', '/folders/{}/delete_files'.format(self.name),
-            {
-                'files': files,
-                'recursive': recursive,
-            })
-        return resp
-
-    def _download(self, files: Sequence[Union[str, Path]],
-                  show_progress: bool = False):
-
-        async def _stream_download():
-            rqst = Request(self._session,
-                'GET', '/folders/{}/download'.format(self.name), {
-                    'files': files,
-                })
-            rqst.date = datetime.now(tzutc())
-            rqst.headers['Date'] = rqst.date.isoformat()
-            try:
-                client = self._session.aiohttp_session
-                rqst._sign()
-                async with _timeout(None):
-                    rqst_ctx = client.request(rqst.method,
-                                              rqst.build_url(),
-                                              data=rqst.pack_content(),
-                                              headers=rqst.headers)
-                    async with rqst_ctx as resp:
-                        if resp.status // 100 != 2:
-                            raise BackendAPIError(resp.status, resp.reason,
-                                                  await resp.text())
-                        total_bytes = int(resp.headers['X-TOTAL-PAYLOADS-LENGTH'])
-                        tqdm_obj = tqdm(desc='Downloading files',
-                                        unit='bytes', unit_scale=True,
-                                        total=total_bytes,
-                                        disable=not show_progress)
-                        reader = aiohttp.MultipartReader.from_response(resp)
-                        with tqdm_obj as pbar:
-                            acc_bytes = 0
-                            while True:
-                                part = await reader.next()
-                                if part is None:
-                                    break
-                                # It seems like that there's no automatic
-                                # decompression steps in multipart reader for
-                                # chuncked encoding.
-                                encoding = part.headers['Content-Encoding']
-                                zlib_mode = (16 + zlib.MAX_WBITS
-                                                 if encoding == 'gzip'
-                                                 else -zlib.MAX_WBITS)
-                                decompressor = zlib.decompressobj(wbits=zlib_mode)
-                                fp = open(part.filename, 'wb')
-                                while True:
-                                    # default chunk size: 8192
-                                    chunk = await part.read_chunk()
-                                    if not chunk:
-                                        break
-                                    raw_chunk = decompressor.decompress(chunk)
-                                    fp.write(raw_chunk)
-                                    acc_bytes += len(raw_chunk)
-                                    pbar.update(len(raw_chunk))
-                                fp.close()
-                            pbar.update(total_bytes - acc_bytes)
-            except (asyncio.CancelledError, asyncio.TimeoutError):
-                # These exceptions must be bubbled up.
-                raise
-            except aiohttp.ClientError as e:
-                msg = 'Request to the API endpoint has failed.\n' \
-                      'Check your network connection and/or the server status.'
-                raise BackendClientError(msg) from e
-
-        self._session.worker_thread.execute(_stream_download())
-
-    def _list_files(self, path: Union[str, Path] = '.'):
-        rqst = Request(self._session, 'GET', '/folders/{}/files'.format(self.name))
+    @api_function
+    async def mkdir(self, path: Union[str, Path]):
+        rqst = Request(self.session, 'POST',
+                       '/folders/{}/mkdir'.format(self.name))
         rqst.set_json({
             'path': path,
         })
-        resp = yield rqst
-        return resp.json()
+        async with rqst.fetch() as resp:
+            return resp
 
-    def _invite(self, perm: str, emails: Sequence[str]):
-        rqst = Request(self._session, 'POST', '/folders/{}/invite'.format(self.name))
+    @api_function
+    async def delete_files(self,
+                            files: Sequence[Union[str, Path]],
+                            recursive: bool = False):
+        rqst = Request(self.session, 'DELETE',
+                       '/folders/{}/delete_files'.format(self.name))
+        rqst.set_json({
+            'files': files,
+            'recursive': recursive,
+        })
+        async with rqst.fetch() as resp:
+            return resp
+
+    @api_function
+    async def download(self, files: Sequence[Union[str, Path]],
+                        show_progress: bool = False):
+
+        rqst = Request(self.session, 'GET',
+                       '/folders/{}/download'.format(self.name))
+        rqst.set_json({
+            'files': files,
+        })
+        try:
+            async with rqst.fetch() as resp:
+                if resp.status // 100 != 2:
+                    raise BackendAPIError(resp.status, resp.reason,
+                                          await resp.text())
+                total_bytes = int(resp.headers['X-TOTAL-PAYLOADS-LENGTH'])
+                tqdm_obj = tqdm(desc='Downloading files',
+                                unit='bytes', unit_scale=True,
+                                total=total_bytes,
+                                disable=not show_progress)
+                reader = aiohttp.MultipartReader.from_response(resp.raw_response)
+                with tqdm_obj as pbar:
+                    acc_bytes = 0
+                    while True:
+                        part = await reader.next()
+                        if part is None:
+                            break
+                        # It seems like that there's no automatic
+                        # decompression steps in multipart reader for
+                        # chuncked encoding.
+                        encoding = part.headers['Content-Encoding']
+                        zlib_mode = (16 + zlib.MAX_WBITS
+                                         if encoding == 'gzip'
+                                         else -zlib.MAX_WBITS)
+                        decompressor = zlib.decompressobj(wbits=zlib_mode)
+                        fp = open(part.filename, 'wb')
+                        while True:
+                            # default chunk size: 8192
+                            chunk = await part.read_chunk()
+                            if not chunk:
+                                break
+                            raw_chunk = decompressor.decompress(chunk)
+                            fp.write(raw_chunk)
+                            acc_bytes += len(raw_chunk)
+                            pbar.update(len(raw_chunk))
+                        fp.close()
+                    pbar.update(total_bytes - acc_bytes)
+        except (asyncio.CancelledError, asyncio.TimeoutError):
+            # These exceptions must be bubbled up.
+            raise
+        except aiohttp.ClientError as e:
+            msg = 'Request to the API endpoint has failed.\n' \
+                  'Check your network connection and/or the server status.'
+            raise BackendClientError(msg) from e
+
+    @api_function
+    async def list_files(self, path: Union[str, Path] = '.'):
+        rqst = Request(self.session, 'GET', '/folders/{}/files'.format(self.name))
+        rqst.set_json({
+            'path': path,
+        })
+        async with rqst.fetch() as resp:
+            return await resp.ajson()
+
+    @api_function
+    async def invite(self, perm: str, emails: Sequence[str]):
+        rqst = Request(self.session, 'POST', '/folders/{}/invite'.format(self.name))
         rqst.set_json({
             'perm': perm, 'user_ids': emails,
         })
-        resp = yield rqst
-        return resp.json()
+        async with rqst.fetch() as resp:
+            return await resp.ajson()
 
+    @api_function
     @classmethod
-    def _invitations(cls):
-        resp = yield Request(cls._session, 'GET', '/folders/invitations/list')
-        return resp.json()
+    async def invitations(cls):
+        rqst = Request(cls.session, 'GET', '/folders/invitations/list')
+        async with rqst.fetch() as resp:
+            return await resp.ajson()
 
+    @api_function
     @classmethod
-    def _accept_invitation(cls, inv_id: str, inv_ak: str):
-        rqst = Request(cls._session, 'POST', '/folders/invitations/accept')
+    async def accept_invitation(cls, inv_id: str, inv_ak: str):
+        rqst = Request(cls.session, 'POST', '/folders/invitations/accept')
         rqst.set_json({'inv_id': inv_id, 'inv_ak': inv_ak})
-        resp = yield rqst
-        return resp.json()
+        async with rqst.fetch() as resp:
+            return await resp.ajson()
 
+    @api_function
     @classmethod
-    def _delete_invitation(cls, inv_id: str):
-        rqst = Request(cls._session, 'DELETE', '/folders/invitations/delete')
+    async def delete_invitation(cls, inv_id: str):
+        rqst = Request(cls.session, 'DELETE', '/folders/invitations/delete')
         rqst.set_json({'inv_id': inv_id})
-        resp = yield rqst
-        return resp.json()
-
-    def __init__(self, name: str):
-        assert _rx_slug.search(name) is not None
-        self.name = name
-        self.delete   = self._call_base_method(self._delete)
-        self.info     = self._call_base_method(self._info)
-        self.upload   = self._call_base_method(self._upload)
-        # self.download = self._call_base_method(self._download)
-        # To deliver loop and session objects to Request.send method.
-        # TODO: Generalized request/response abstraction accounting for streaming
-        #       would be needed.
-        self.download = self._download
-        self.mkdir = self._call_base_method(self._mkdir)
-        self.delete_files = self._call_base_method(self._delete_files)
-        self.list_files = self._call_base_method(self._list_files)
-        self.invite = self._call_base_method(self._invite)
-
-    def __init_subclass__(cls):
-        cls.create = cls._call_base_clsmethod(cls._create)
-        cls.list   = cls._call_base_clsmethod(cls._list)
-        cls.get    = cls._get  # this is wrapper of constructor, not API func.
-        cls.invitations = cls._call_base_clsmethod(cls._invitations)
-        cls.accept_invitation = cls._call_base_clsmethod(cls._accept_invitation)
-        cls.delete_invitation = cls._call_base_clsmethod(cls._delete_invitation)
-
-
-class VFolder(SyncFunctionMixin, BaseVFolder):
-    '''
-    Deprecated! Use ai.backend.client.Session instead.
-    '''
-    pass
+        async with rqst.fetch() as resp:
+            return await resp.ajson()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,11 @@ def defconfig():
 
 
 @pytest.fixture
+def example_keypair():
+    return ('AKIAIOSFODNN7EXAMPLE', 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY')
+
+
+@pytest.fixture
 def dummy_endpoint(defconfig):
     return str(defconfig.endpoint) + '/'
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,4 +14,9 @@ def defconfig():
 
 @pytest.fixture
 def dummy_endpoint(defconfig):
-    return str(defconfig.endpoint) + '/v2/'
+    return str(defconfig.endpoint) + '/'
+
+
+@pytest.fixture
+def dummy_endpoint_versioned(defconfig):
+    return str(defconfig.endpoint) + '/v4/'

--- a/tests/test_cli_proxy.py
+++ b/tests/test_cli_proxy.py
@@ -75,9 +75,12 @@ def proxy_app(event_loop):
 
 
 @pytest.mark.asyncio
-async def test_proxy_web(monkeypatch, api_app, proxy_app, unused_tcp_port_factory):
+async def test_proxy_web(monkeypatch, example_keypair, api_app, proxy_app,
+                         unused_tcp_port_factory):
     api_port = unused_tcp_port_factory()
     api_url = 'http://127.0.0.1:{}'.format(api_port)
+    monkeypatch.setenv('BACKEND_ACCESS_KEY', example_keypair[0])
+    monkeypatch.setenv('BACKEND_SECRET_KEY', example_keypair[1])
     monkeypatch.setenv('BACKEND_ENDPOINT', api_url)
     monkeypatch.setattr(config, '_config', config.APIConfig())
     api_app, recv_queue = await api_app(api_port)
@@ -95,9 +98,12 @@ async def test_proxy_web(monkeypatch, api_app, proxy_app, unused_tcp_port_factor
 
 
 @pytest.mark.asyncio
-async def test_proxy_web_502(monkeypatch, proxy_app, unused_tcp_port_factory):
+async def test_proxy_web_502(monkeypatch, example_keypair, proxy_app,
+                             unused_tcp_port_factory):
     api_port = unused_tcp_port_factory()
     api_url = 'http://127.0.0.1:{}'.format(api_port)
+    monkeypatch.setenv('BACKEND_ACCESS_KEY', example_keypair[0])
+    monkeypatch.setenv('BACKEND_SECRET_KEY', example_keypair[1])
     monkeypatch.setenv('BACKEND_ENDPOINT', api_url)
     monkeypatch.setattr(config, '_config', config.APIConfig())
     # Skip creation of api_app; let the proxy use a non-existent server.
@@ -113,10 +119,12 @@ async def test_proxy_web_502(monkeypatch, proxy_app, unused_tcp_port_factory):
 
 
 @pytest.mark.asyncio
-async def test_proxy_websocket(monkeypatch, api_app, proxy_app,
+async def test_proxy_websocket(monkeypatch, example_keypair, api_app, proxy_app,
                                unused_tcp_port_factory):
     api_port = unused_tcp_port_factory()
     api_url = 'http://127.0.0.1:{}'.format(api_port)
+    monkeypatch.setenv('BACKEND_ACCESS_KEY', example_keypair[0])
+    monkeypatch.setenv('BACKEND_SECRET_KEY', example_keypair[1])
     monkeypatch.setenv('BACKEND_ENDPOINT', api_url)
     monkeypatch.setattr(config, '_config', config.APIConfig())
     api_app, recv_queue = await api_app(api_port)

--- a/tests/test_cli_proxy.py
+++ b/tests/test_cli_proxy.py
@@ -1,0 +1,137 @@
+from argparse import Namespace
+import os
+
+import aiohttp
+from aiohttp import web
+import pytest
+
+from ai.backend.client import config
+from ai.backend.client.cli.proxy import proxy as proxy_command
+
+
+@pytest.fixture
+def api_app(event_loop):
+    app = web.Application()
+    recv_queue = []
+
+    async def echo_ws(request):
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        async for msg in ws:
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                recv_queue.append(msg)
+                await ws.send_str(msg.data)
+            elif msg.type == aiohttp.WSMsgType.BINARY:
+                recv_queue.append(msg)
+                await ws.send_bytes(msg.data)
+            elif msg.type == aiohttp.WSMsgType.ERROR:
+                recv_queue.append(msg)
+        return ws
+
+    async def echo_web(request):
+        body = await request.read()
+        resp = web.Response(status=200, reason='Good', body=body)
+        resp.headers['Content-Type'] = request.content_type
+        return resp
+
+    app.router.add_route('GET', r'/stream/echo', echo_ws)
+    app.router.add_route('POST', r'/echo', echo_web)
+    runner = web.AppRunner(app)
+
+    async def start(port):
+        await runner.setup()
+        site = web.TCPSite(runner, '127.0.0.1', port)
+        await site.start()
+        return app, recv_queue
+
+    async def shutdown():
+        await runner.cleanup()
+
+    try:
+        yield start
+    finally:
+        event_loop.run_until_complete(shutdown())
+
+
+@pytest.fixture
+def proxy_app(event_loop):
+    args = Namespace()
+    args.testing = True
+    app = proxy_command(args)
+    runner = web.AppRunner(app)
+
+    async def start(port):
+        await runner.setup()
+        site = web.TCPSite(runner, '127.0.0.1', port)
+        await site.start()
+        return app
+
+    async def shutdown():
+        await runner.cleanup()
+
+    try:
+        yield start
+    finally:
+        event_loop.run_until_complete(shutdown())
+
+
+@pytest.mark.asyncio
+async def test_proxy_web(monkeypatch, api_app, proxy_app, unused_tcp_port_factory):
+    api_port = unused_tcp_port_factory()
+    api_url = 'http://127.0.0.1:{}'.format(api_port)
+    monkeypatch.setenv('BACKEND_ENDPOINT', api_url)
+    monkeypatch.setattr(config, '_config', config.APIConfig())
+    api_app, recv_queue = await api_app(api_port)
+    proxy_client = aiohttp.ClientSession()
+    proxy_port = unused_tcp_port_factory()
+    proxy_app = await proxy_app(proxy_port)
+    proxy_url = 'http://127.0.0.1:{}'.format(proxy_port)
+    data = {"test": 1234}
+    async with proxy_client.request('POST', proxy_url + '/echo',
+                                    json=data) as resp:
+        assert resp.status == 200
+        assert resp.reason == 'Good'
+        ret = await resp.json()
+        assert ret['test'] == 1234
+
+
+@pytest.mark.asyncio
+async def test_proxy_web_502(monkeypatch, proxy_app, unused_tcp_port_factory):
+    api_port = unused_tcp_port_factory()
+    api_url = 'http://127.0.0.1:{}'.format(api_port)
+    monkeypatch.setenv('BACKEND_ENDPOINT', api_url)
+    monkeypatch.setattr(config, '_config', config.APIConfig())
+    # Skip creation of api_app; let the proxy use a non-existent server.
+    proxy_client = aiohttp.ClientSession()
+    proxy_port = unused_tcp_port_factory()
+    proxy_app = await proxy_app(proxy_port)
+    proxy_url = 'http://127.0.0.1:{}'.format(proxy_port)
+    data = {"test": 1234}
+    async with proxy_client.request('POST', proxy_url + '/echo',
+                                    json=data) as resp:
+        assert resp.status == 502
+        assert resp.reason == 'Bad Gateway'
+
+
+@pytest.mark.asyncio
+async def test_proxy_websocket(monkeypatch, api_app, proxy_app,
+                               unused_tcp_port_factory):
+    api_port = unused_tcp_port_factory()
+    api_url = 'http://127.0.0.1:{}'.format(api_port)
+    monkeypatch.setenv('BACKEND_ENDPOINT', api_url)
+    monkeypatch.setattr(config, '_config', config.APIConfig())
+    api_app, recv_queue = await api_app(api_port)
+    proxy_client = aiohttp.ClientSession()
+    proxy_port = unused_tcp_port_factory()
+    proxy_app = await proxy_app(proxy_port)
+    proxy_url = 'http://127.0.0.1:{}'.format(proxy_port)
+    ws = await proxy_client.ws_connect(proxy_url + '/stream/echo')
+    await ws.send_str('test')
+    assert await ws.receive_str() == 'test'
+    await ws.send_bytes(b'\x00\x00')
+    assert await ws.receive_bytes() == b'\x00\x00'
+    assert recv_queue[0].type == aiohttp.WSMsgType.TEXT
+    assert recv_queue[0].data == 'test'
+    assert recv_queue[1].type == aiohttp.WSMsgType.BINARY
+    assert recv_queue[1].data == b'\x00\x00'
+    await ws.close()

--- a/tests/test_cli_proxy.py
+++ b/tests/test_cli_proxy.py
@@ -1,5 +1,4 @@
 from argparse import Namespace
-import os
 
 import aiohttp
 from aiohttp import web

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -56,8 +56,8 @@ def aggregate_console(c):
 def intgr_config():
     return APIConfig(
         endpoint='http://localhost:8081',
-        access_key='',
-        secret_key='',
+        access_key='AKIAIOSFODNN7EXAMPLE',
+        secret_key='wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
     )
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -38,8 +38,8 @@ import pytest
 
 from ai.backend.client.compat import token_hex
 from ai.backend.client.request import Request
-from ai.backend.client.admin import Admin
-from ai.backend.client.kernel import Kernel
+from ai.backend.client.config import APIConfig
+from ai.backend.client import Session, AsyncSession
 from ai.backend.client.exceptions import BackendAPIError
 
 
@@ -52,107 +52,146 @@ def aggregate_console(c):
     }
 
 
-@pytest.mark.integration
-def test_connection(defconfig):
-    request = Request('GET', '/')
-    resp = request.fetch()
-    assert 'version' in resp.json()
+@pytest.fixture
+def intgr_config():
+    return APIConfig(
+        endpoint='http://localhost:8081',
+        access_key='',
+        secret_key='',
+    )
 
 
 @pytest.mark.integration
-def test_not_found(defconfig):
-    request = Request('GET', '/invalid-url-wow')
-    resp = request.fetch()
-    assert resp.status == 404
-    request = Request('GET', '/authorize/uh-oh')
-    resp = request.fetch()
-    assert resp.status == 404
+def test_connection(intgr_config):
+    with Session(config=intgr_config) as sess:
+        request = Request(sess, 'GET', '/')
+        with request.fetch() as resp:
+            assert 'version' in resp.json()
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_async_connection(defconfig):
-    request = Request('GET', '/')
-    resp = await request.afetch()
-    assert 'version' in resp.json()
-
-
-@pytest.mark.integration
-def test_auth(defconfig):
-    random_msg = uuid.uuid4().hex
-    request = Request('GET', '/authorize', {
-        'echo': random_msg,
-    })
-    resp = request.fetch()
-    assert resp.status == 200
-    data = resp.json()
-    assert data['authorized'] == 'yes'
-    assert data['echo'] == random_msg
-
-
-@pytest.mark.integration
-def test_auth_missing_signature(defconfig):
-    random_msg = uuid.uuid4().hex
-    request = Request('GET', '/authorize', {
-        'echo': random_msg,
-    })
-    # let it bypass actual signing
-    request._sign = lambda *args, **kwargs: None
-    resp = request.fetch()
-    assert resp.status == 401
-
-
-@pytest.mark.integration
-def test_auth_malformed(defconfig):
-    request = Request('GET', '/authorize')
-    request.content = b'<this is not json>'
-    resp = request.fetch()
-    assert resp.status == 400
-
-
-@pytest.mark.integration
-def test_auth_missing_body(defconfig):
-    request = Request('GET', '/authorize')
-    resp = request.fetch()
-    assert resp.status == 400
+def test_not_found(intgr_config):
+    with Session(config=intgr_config) as sess:
+        request = Request(sess, 'GET', '/invalid-url-wow')
+        with pytest.raises(BackendAPIError) as e:
+            with request.fetch():
+                pass
+        assert e.value.status == 404
+        request = Request(sess, 'GET', '/auth/uh-oh')
+        with pytest.raises(BackendAPIError) as e:
+            with request.fetch():
+                pass
+        assert e.value.status == 404
 
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_async_auth(defconfig):
-    random_msg = uuid.uuid4().hex
-    request = Request('GET', '/authorize', {
-        'echo': random_msg,
-    })
-    resp = await request.afetch()
-    assert resp.status == 200
-    data = resp.json()
-    assert data['authorized'] == 'yes'
-    assert data['echo'] == random_msg
+async def test_async_connection(intgr_config):
+    async with AsyncSession(config=intgr_config) as sess:
+        request = Request(sess, 'GET', '/')
+        async with request.fetch() as resp:
+            assert 'version' in await resp.json()
 
 
 @pytest.mark.integration
-def test_kernel_lifecycles(defconfig):
-    kernel = Kernel.get_or_create('python:latest')
-    kernel_id = kernel.kernel_id
-    info = kernel.get_info()
-    assert info['lang'] == 'python:latest'
-    assert info['numQueriesExecuted'] == 1
-    info = kernel.get_info()
-    assert info['numQueriesExecuted'] == 2
-    kernel.destroy()
-    # kernel destruction is no longer synchronous!
-    time.sleep(2.0)
-    with pytest.raises(BackendAPIError) as e:
-        info = Kernel(kernel_id).get_info()
-    assert e.value.args[0] == 404
+def test_auth(intgr_config):
+    random_msg = uuid.uuid4().hex
+    with Session(config=intgr_config) as sess:
+        request = Request(sess, 'GET', '/auth')
+        request.set_json({
+            'echo': random_msg,
+        })
+        with request.fetch() as resp:
+            assert resp.status == 200
+            data = resp.json()
+            assert data['authorized'] == 'yes'
+            assert data['echo'] == random_msg
+
+
+@pytest.mark.integration
+def test_auth_missing_signature(intgr_config, monkeypatch):
+    random_msg = uuid.uuid4().hex
+    with Session(config=intgr_config) as sess:
+        rqst = Request(sess, 'GET', '/auth')
+        rqst.set_json({
+            'echo': random_msg,
+        })
+        # let it bypass actual signing
+        from ai.backend.client import request
+        noop_sign = lambda *args, **kwargs: ({}, None)
+        monkeypatch.setattr(request, 'generate_signature', noop_sign)
+        with pytest.raises(BackendAPIError) as e:
+            with rqst.fetch():
+                pass
+        assert e.value.status == 401
+
+
+@pytest.mark.integration
+def test_auth_malformed(intgr_config):
+    with Session(config=intgr_config) as sess:
+        request = Request(sess, 'GET', '/auth')
+        request.set_content(
+            b'<this is not json>',
+            content_type='application/json',
+        )
+        with pytest.raises(BackendAPIError) as e:
+            with request.fetch():
+                pass
+        assert e.value.status == 400
+
+
+@pytest.mark.integration
+def test_auth_missing_body(intgr_config):
+    with Session(config=intgr_config) as sess:
+        request = Request(sess, 'GET', '/auth')
+        with pytest.raises(BackendAPIError) as e:
+            with request.fetch():
+                pass
+        assert e.value.status == 400
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_async_auth(intgr_config):
+    random_msg = uuid.uuid4().hex
+    async with AsyncSession(config=intgr_config) as sess:
+        request = Request(sess, 'GET', '/auth')
+        request.set_json({
+            'echo': random_msg,
+        })
+        async with request.fetch() as resp:
+            assert resp.status == 200
+            data = await resp.json()
+            assert data['authorized'] == 'yes'
+            assert data['echo'] == random_msg
+
+
+@pytest.mark.integration
+def test_kernel_lifecycles(intgr_config):
+    with Session(config=intgr_config) as sess:
+        kernel = sess.Kernel.get_or_create('python:latest')
+        kernel_id = kernel.kernel_id
+        info = kernel.get_info()
+        # the tag may be different depending on alias/metadata config.
+        lang = info['lang']
+        assert lang.startswith('python:') or lang.startswith('lablup/python:')
+        assert info['numQueriesExecuted'] == 1
+        info = kernel.get_info()
+        assert info['numQueriesExecuted'] == 2
+        kernel.destroy()
+        # kernel destruction is no longer synchronous!
+        time.sleep(2.0)
+        with pytest.raises(BackendAPIError) as e:
+            info = sess.Kernel(kernel_id).get_info()
+        assert e.value.status == 404
 
 
 @pytest.yield_fixture
-def py3_kernel():
-    kernel = Kernel.get_or_create('python:latest')
-    yield kernel
-    kernel.destroy()
+def py3_kernel(intgr_config):
+    with Session(config=intgr_config) as sess:
+        kernel = sess.Kernel.get_or_create('python:latest')
+        yield kernel
+        kernel.destroy()
 
 
 def exec_loop(kernel, code):
@@ -171,7 +210,7 @@ def exec_loop(kernel, code):
 
 
 @pytest.mark.integration
-def test_kernel_execution(defconfig, py3_kernel):
+def test_kernel_execution(py3_kernel):
     console, n = exec_loop(py3_kernel, 'print("hello world"); raise RuntimeError()')
     assert 'hello world' in console['stdout']
     assert 'RuntimeError' in console['stderr']
@@ -181,7 +220,7 @@ def test_kernel_execution(defconfig, py3_kernel):
 
 
 @pytest.mark.integration
-def test_kernel_restart(defconfig, py3_kernel):
+def test_kernel_restart(py3_kernel):
     num_queries = 1  # first query is done by py3_kernel fixture (creation)
     first_code = textwrap.dedent('''
     a = "first"
@@ -218,16 +257,18 @@ def test_kernel_restart(defconfig, py3_kernel):
 
 
 @pytest.mark.integration
-def test_admin_api(defconfig, py3_kernel):
+def test_admin_api(py3_kernel):
+    sess = py3_kernel.session
     q = '''
     query($ak: String!) {
         compute_sessions(access_key: $ak, status: "RUNNING") {
             lang
         }
     }'''
-    resp = Admin.query(q, {
-        'ak': defconfig.access_key,
+    resp = sess.Admin.query(q, {
+        'ak': sess.config.access_key,
     })
     assert 'compute_sessions' in resp
     assert len(resp['compute_sessions']) >= 1
-    assert resp['compute_sessions'][0]['lang'] == 'python:latest'
+    lang = resp['compute_sessions'][0]['lang']
+    assert lang.startswith('python:') or lang.startswith('lablup/python:')

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -12,7 +12,7 @@ from ai.backend.client.session import Session
 def test_create_with_config(mocker):
     mock_req_obj = mock.Mock()
     mock_req_obj.fetch.return_value = mocker.MagicMock(status=201,
-                                                      json=mock.MagicMock())
+                                                       json=mock.MagicMock())
     mock_req = mocker.patch('ai.backend.client.kernel.Request',
                             return_value=mock_req_obj)
 
@@ -27,10 +27,10 @@ def test_create_with_config(mocker):
         k = session.Kernel.get_or_create('python')
         mock_req.assert_called_once_with(session,
                                          'POST', '/kernel/create', mocker.ANY)
-        assert str(k._session.config.endpoint) == 'https://localhost:9999'
-        assert k._session.config.user_agent == 'BAIClientTest'
-        assert k._session.config.access_key == '1234'
-        assert k._session.config.secret_key == 'asdf'
+        assert str(k.session.config.endpoint) == 'https://localhost:9999'
+        assert k.session.config.user_agent == 'BAIClientTest'
+        assert k.session.config.access_key == '1234'
+        assert k.session.config.secret_key == 'asdf'
 
 
 def test_deprecated_api():
@@ -41,7 +41,7 @@ def test_deprecated_api():
 def test_create_kernel_url(mocker):
     mock_req_obj = mock.Mock()
     mock_req_obj.fetch.return_value = mocker.MagicMock(status=201,
-                                                      json=mock.MagicMock())
+                                                       json=mock.MagicMock())
     mock_req = mocker.patch('ai.backend.client.kernel.Request',
                             return_value=mock_req_obj)
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -94,11 +94,11 @@ def test_build_correct_url(mock_request_params):
 
     mock_request_params['path'] = '/function'
     rqst = Request(**mock_request_params)
-    assert rqst.build_url() == canonical_url
+    assert rqst._build_url() == canonical_url
 
     mock_request_params['path'] = 'function'
     rqst = Request(**mock_request_params)
-    assert rqst.build_url() == canonical_url
+    assert rqst._build_url() == canonical_url
 
 
 def test_fetch_invalid_method(mock_request_params):

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,5 +1,5 @@
+from argparse import Namespace
 import asyncio
-from collections import OrderedDict
 import io
 import json
 
@@ -8,19 +8,25 @@ from aioresponses import aioresponses
 import pytest
 
 from ai.backend.client.exceptions import BackendClientError
-from ai.backend.client.request import Request, Response, StreamingResponse
+from ai.backend.client.request import Request, Response, AttachedFile
 from ai.backend.client.session import Session, AsyncSession
 
 
 @pytest.fixture
-def mock_request_params(defconfig):
+def session(defconfig):
     with Session(config=defconfig) as session:
-        yield OrderedDict(
-            session=session,
-            method='GET',
-            path='/function/item/',
-            content=OrderedDict(test1='1'),
-        )
+        yield session
+
+
+@pytest.fixture
+def mock_request_params(session):
+    yield {
+        'session': session,
+        'method': 'GET',
+        'path': '/function/item/',
+        'content': b'{"test1": 1}',
+        'content_type': 'application/json',
+    }
 
 
 def test_request_initialization(mock_request_params):
@@ -31,82 +37,77 @@ def test_request_initialization(mock_request_params):
     assert rqst.path == mock_request_params['path'].lstrip('/')
     assert rqst.content == mock_request_params['content']
     assert 'X-BackendAI-Version' in rqst.headers
-    assert rqst._content == json.dumps(mock_request_params['content']).encode('utf8')
 
 
-def test_content_is_auto_set_to_blank_if_no_data(mock_request_params):
+def test_request_set_content_none(mock_request_params):
     mock_request_params = mock_request_params.copy()
     mock_request_params['content'] = None
     rqst = Request(**mock_request_params)
-
-    assert rqst.content_type == 'application/octet-stream'
     assert rqst.content == b''
+    assert rqst._pack_content() is rqst.content
 
 
-def test_content_is_blank(mock_request_params):
-    mock_request_params['content'] = OrderedDict()
+def test_request_set_content(mock_request_params):
     rqst = Request(**mock_request_params)
-
+    assert rqst.content == mock_request_params['content']
     assert rqst.content_type == 'application/json'
-    assert rqst.content == {}
+    assert rqst._pack_content() is rqst.content
 
-
-def test_content_is_bytes(mock_request_params):
-    mock_request_params['content'] = b'\xff\xf1'
-    rqst = Request(**mock_request_params)
-
-    assert rqst.content_type == 'application/octet-stream'
-    assert rqst.content == b'\xff\xf1'
-
-
-def test_content_is_text(mock_request_params):
     mock_request_params['content'] = 'hello'
+    mock_request_params['content_type'] = None
     rqst = Request(**mock_request_params)
-
+    assert rqst.content == b'hello'
     assert rqst.content_type == 'text/plain'
-    assert rqst.content == 'hello'
+    assert rqst._pack_content() is rqst.content
 
-
-def test_content_is_files(mock_request_params):
-    files = [
-        ('src', 'test1.txt', io.BytesIO(), 'application/octet-stream'),
-        ('src', 'test2.txt', io.BytesIO(), 'application/octet-stream'),
-    ]
-    mock_request_params['content'] = files
+    mock_request_params['content'] = b'\x00\x01\xfe\xff'
+    mock_request_params['content_type'] = None
     rqst = Request(**mock_request_params)
+    assert rqst.content == b'\x00\x01\xfe\xff'
+    assert rqst.content_type == 'application/octet-stream'
+    assert rqst._pack_content() is rqst.content
+
+
+def test_request_attach_files(mock_request_params):
+    files = [
+        AttachedFile('test1.txt', io.BytesIO(), 'application/octet-stream'),
+        AttachedFile('test2.txt', io.BytesIO(), 'application/octet-stream'),
+    ]
+
+    mock_request_params['content'] = b'something'
+    rqst = Request(**mock_request_params)
+    with pytest.raises(AssertionError):
+        rqst.attach_files(files)
+
+    mock_request_params['content'] = b''
+    rqst = Request(**mock_request_params)
+    rqst.attach_files(files)
 
     assert rqst.content_type == 'multipart/form-data'
-    assert rqst.content == files
-
-
-def test_set_content_correctly(mock_request_params):
-    mock_request_params['content'] = OrderedDict()
-    rqst = Request(**mock_request_params)
-    new_data = b'new-data'
-
-    assert not rqst.content
-    rqst.content = new_data
-    assert rqst.content == new_data
-    assert rqst.headers['Content-Length'] == str(len(new_data))
+    assert rqst.content == b''
+    packed_content = rqst._pack_content()
+    assert packed_content.is_multipart
 
 
 def test_build_correct_url(mock_request_params):
-    config = mock_request_params['session'].config
+    canonical_url = 'http://127.0.0.1:8081/function'
+
+    mock_request_params['path'] = '/function'
     rqst = Request(**mock_request_params)
+    assert rqst.build_url() == canonical_url
 
-    major_ver = config.version.split('.', 1)[0]
-    path = '/' + rqst.path if len(rqst.path) > 0 else ''
-
-    canonical_url = 'http://127.0.0.1:8081/{0}{1}'.format(major_ver, path)
+    mock_request_params['path'] = 'function'
+    rqst = Request(**mock_request_params)
     assert rqst.build_url() == canonical_url
 
 
-def test_fetch_not_allowed_request_raises_error(mock_request_params):
+def test_fetch_invalid_method(mock_request_params):
     mock_request_params['method'] = 'STRANGE'
     rqst = Request(**mock_request_params)
 
     with pytest.raises(AssertionError):
-        rqst.fetch()
+        with rqst.fetch():
+            pass
 
 
 def test_fetch(dummy_endpoint):
@@ -119,13 +120,12 @@ def test_fetch(dummy_endpoint):
                      'Content-Length': str(len(body))},
         )
         rqst = Request(session, 'POST', 'function')
-        resp = rqst.fetch()
-        assert isinstance(resp, Response)
-        assert resp.status == 200
-        assert resp.charset == 'utf-8'
-        assert resp.content_type == 'text/plain'
-        assert resp.text() == body.decode()
-        assert resp.content_length == len(body)
+        with rqst.fetch() as resp:
+            assert isinstance(resp, Response)
+            assert resp.status == 200
+            assert resp.content_type == 'text/plain'
+            assert resp.text() == body.decode()
+            assert resp.content_length == len(body)
 
     with aioresponses() as m, Session() as session:
         body = b'{"a": 1234, "b": null}'
@@ -135,18 +135,16 @@ def test_fetch(dummy_endpoint):
                      'Content-Length': str(len(body))},
         )
         rqst = Request(session, 'POST', 'function')
-        resp = rqst.fetch()
-        assert isinstance(resp, Response)
-        assert resp.status == 200
-        assert resp.charset == 'utf-8'
-        assert resp.content_type == 'application/json'
-        assert resp.text() == body.decode()
-        assert resp.json() == {'a': 1234, 'b': None}
-        assert resp.content_length == len(body)
+        with rqst.fetch() as resp:
+            assert isinstance(resp, Response)
+            assert resp.status == 200
+            assert resp.charset == 'utf-8'
+            assert resp.content_type == 'application/json'
+            assert resp.text() == body.decode()
+            assert resp.json() == {'a': 1234, 'b': None}
+            assert resp.content_length == len(body)
 
 
-# TODO: fix up
-@pytest.mark.xfail
 def test_streaming_fetch(dummy_endpoint):
     # Read content by chunks.
     with aioresponses() as m, Session() as session:
@@ -156,19 +154,15 @@ def test_streaming_fetch(dummy_endpoint):
             headers={'Content-Type': 'text/plain; charset=utf-8',
                      'Content-Length': str(len(body))},
         )
-        rqst = Request(session, 'POST', 'function', streaming=True)
-        resp = rqst.fetch()
-        assert isinstance(resp, StreamingResponse)
-        assert resp.status == 200
-        assert resp.content_type == 'text/plain'
-        assert not resp.stream.at_eof
-        assert resp.read(3) == b'hel'
-        assert resp.read(2) == b'lo'
-        assert not resp.stream.at_eof
-        resp.read()
-        assert resp.stream.at_eof
-        with pytest.raises(AssertionError):
-            assert resp.text()
+        rqst = Request(session, 'POST', 'function')
+        with rqst.fetch() as resp:
+            assert resp.status == 200
+            assert resp.content_type == 'text/plain'
+            assert resp.read(3) == b'hel'
+            assert resp.read(2) == b'lo'
+            resp.read()
+            with pytest.raises(AssertionError):
+                assert resp.text()
 
 
 def test_invalid_requests(dummy_endpoint):
@@ -183,16 +177,15 @@ def test_invalid_requests(dummy_endpoint):
                      'Content-Length': str(len(body))},
         )
         rqst = Request(session, 'POST', '/')
-        resp = rqst.fetch()
-        assert isinstance(resp, Response)
-        assert resp.status == 404
-        assert resp.charset == 'utf-8'
-        assert resp.content_type == 'application/problem+json'
-        assert resp.text() == body.decode()
-        assert resp.content_length == len(body)
-        data = resp.json()
-        assert data['type'] == 'https://api.backend.ai/probs/kernel-not-found'
-        assert data['title'] == 'Kernel Not Found'
+        with rqst.fetch() as resp:
+            assert resp.status == 404
+            assert resp.charset == 'utf-8'
+            assert resp.content_type == 'application/problem+json'
+            assert resp.text() == body.decode()
+            assert resp.content_length == len(body)
+            data = resp.json()
+            assert data['type'] == 'https://api.backend.ai/probs/kernel-not-found'
+            assert data['title'] == 'Kernel Not Found'
 
 
 @pytest.mark.asyncio
@@ -200,7 +193,8 @@ async def test_afetch_not_allowed_request_raises_error():
     async with AsyncSession() as session:
         rqst = Request(session, 'STRANGE', '/')
         with pytest.raises(AssertionError):
-            await rqst.afetch()
+            async with rqst.afetch():
+                pass
 
 
 @pytest.mark.asyncio
@@ -211,7 +205,8 @@ async def test_afetch_client_error(dummy_endpoint):
                    exception=aiohttp.ClientConnectionError())
             rqst = Request(session, 'POST', '/')
             with pytest.raises(BackendClientError):
-                await rqst.afetch()
+                async with rqst.afetch():
+                    pass
 
 
 @pytest.mark.asyncio
@@ -222,7 +217,8 @@ async def test_afetch_cancellation(dummy_endpoint):
                    exception=asyncio.CancelledError())
             rqst = Request(session, 'POST', '/')
             with pytest.raises(asyncio.CancelledError):
-                await rqst.afetch()
+                async with rqst.afetch():
+                    pass
 
 
 @pytest.mark.asyncio
@@ -233,18 +229,36 @@ async def test_afetch_timeout(dummy_endpoint):
                    exception=asyncio.TimeoutError())
             rqst = Request(session, 'POST', '/')
             with pytest.raises(asyncio.TimeoutError):
-                await rqst.afetch()
+                async with rqst.afetch():
+                    pass
 
 
-def test_response_initialization():
-    body = b'my precious content \xea\xb0\x80..'
-    mock_session = object()
-    mock_resp = object()
-    resp = Response(mock_session, mock_resp,
-                    body=body,
-                    content_type='text/plain')
-    assert resp.session is mock_session
-    assert resp.raw_response is mock_resp
-    assert resp.content_type == 'text/plain'
-    assert resp.text() == 'my precious content 가..'
-    assert resp.content_length == len(body)
+def test_response_sync(defconfig, dummy_endpoint):
+    body = b'{"test": 1234}'
+    with aioresponses() as m:
+        m.post(
+            dummy_endpoint + 'function', status=200, body=body,
+            headers={'Content-Type': 'applicaiton/json',
+                     'Content-Length': str(len(body))},
+        )
+        with Session(config=defconfig) as session:
+            rqst = Request(session, 'POST', '/function')
+            with rqst.fetch() as resp:
+                assert resp.text() == '{"test": 1234}'
+                assert resp.json() == {'test': 1234}
+
+
+@pytest.mark.asyncio
+async def test_response_async(defconfig, dummy_endpoint):
+    body = b'{"test": 5678}'
+    with aioresponses() as m:
+        m.post(
+            dummy_endpoint + 'function', status=200, body=body,
+            headers={'Content-Type': 'application/json',
+                     'Content-Length': str(len(body))},
+        )
+        async with AsyncSession(config=defconfig) as session:
+            rqst = Request(session, 'POST', '/function')
+            async with rqst.afetch() as resp:
+                assert await resp.text() == '{"test": 5678}'
+                assert await resp.json() == {'test': 5678}

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,4 +1,3 @@
-from argparse import Namespace
 import asyncio
 import io
 import json

--- a/tests/test_vfolder.py
+++ b/tests/test_vfolder.py
@@ -5,9 +5,8 @@ from ai.backend.client.session import Session
 
 def build_url(config, path):
     base_url = config.endpoint.path.rstrip('/')
-    major_ver = config.version.split('.', 1)[0]
     query_path = path.lstrip('/') if len(path) > 0 else ''
-    path = '{0}/{1}/{2}'.format(base_url, major_ver, query_path)
+    path = '{0}/{1}'.format(base_url, query_path)
     canonical_url = config.endpoint.with_path(path)
     return canonical_url
 

--- a/tests/test_vfolder.py
+++ b/tests/test_vfolder.py
@@ -18,7 +18,7 @@ def test_create_vfolder():
                 'id': 'fake-vfolder-id',
                 'name': 'fake-vfolder-name',
             }
-            m.post(build_url(session.config, '/folders/'), status=201,
+            m.post(build_url(session.config, '/folders'), status=201,
                    payload=payload)
             resp = session.VFolder.create('fake-vfolder-name')
             assert resp == payload
@@ -37,7 +37,7 @@ def test_list_vfolders():
                     'id': 'fake-vfolder2-id'
                 }
             ]
-            m.get(build_url(session.config, '/folders/'), status=200,
+            m.get(build_url(session.config, '/folders'), status=200,
                   payload=payload)
             resp = session.VFolder.list()
             assert resp == payload


### PR DESCRIPTION
* Use aiohttp's startup/cleanup signals to initialize and destroy the client session.
* Use the client session everywhere for the lifetime of proxy command.
* Adopt API v4's authentication mechanism which do not include the body. (lablup/backend.ai#30)
* Use metaclass to seamlessly wrap async API functions as synchronous versions.