### PR TITLE
Adapt Click package for cli development

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,8 +97,8 @@ setup(
     entry_points={
         'console_scripts': [
             'backend.ai = ai.backend.client.cli:main',
-            'lcc = ai.backend.client.cli:main',
-            'lpython = ai.backend.client.cli:main',
+            'lcc = ai.backend.client.cli:run_alias',
+            'lpython = ai.backend.client.cli:run_alias',
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,11 @@ install_requires = [
     'attrs>=18.0',       # to avoid pip10 resolver issue
     'namedlist>=1.6',
     'python-dateutil>=2.5',
-    'ConfigArgParse==0.12.0',
     'tabulate>=0.7.7',
     'tqdm~=4.21',
     'humanize>=0.5.1',
     'yarl>=1.1.1',
+    'Click>=7.0',
 ]
 build_requires = [
     'wheel>=0.31.0',

--- a/src/ai/backend/client/cli/__init__.py
+++ b/src/ai/backend/client/cli/__init__.py
@@ -78,30 +78,6 @@ class AliasGroup(click.Group):
                     formatter.write_dl(rows)
 
 
-# def main():
-
-#     if len(sys.argv) <= 1:
-#         global_argparser.print_help()
-#         return
-
-#     mode = Path(sys.argv[0]).stem
-
-#     if mode == '__main__':
-#         pass
-#     elif mode == 'lcc':
-#         sys.argv.insert(1, 'c')
-#         sys.argv.insert(1, 'run')
-#     elif mode == 'lpython':
-#         sys.argv.insert(1, 'python')
-#         sys.argv.insert(1, 'run')
-
-#     args = global_argparser.parse_args()
-#     if hasattr(args, 'function'):
-#         args.function(args)
-#     else:
-#         print_fail('The command is not specified or unrecognized.')
-
-
 @click.group(cls=AliasGroup,
              context_settings=dict(help_option_names=['-h', '--help']))
 @click.version_option()

--- a/src/ai/backend/client/cli/__init__.py
+++ b/src/ai/backend/client/cli/__init__.py
@@ -5,21 +5,6 @@ from .pretty import print_fail
 
 # def main():
 
-#     import ai.backend.client.cli.config # noqa
-#     import ai.backend.client.cli.run    # noqa
-#     import ai.backend.client.cli.proxy  # noqa
-#     import ai.backend.client.cli.admin  # noqa
-#     import ai.backend.client.cli.admin.keypairs  # noqa
-#     import ai.backend.client.cli.admin.sessions  # noqa
-#     import ai.backend.client.cli.admin.agents    # noqa
-#     import ai.backend.client.cli.admin.vfolders  # noqa
-#     import ai.backend.client.cli.manager  # noqa
-#     import ai.backend.client.cli.vfolder # noqa
-#     import ai.backend.client.cli.ps     # noqa
-#     import ai.backend.client.cli.logs   # noqa
-#     import ai.backend.client.cli.files           # noqa
-#     import ai.backend.client.cli.app  # noqa
-
 #     if len(sys.argv) <= 1:
 #         global_argparser.print_help()
 #         return
@@ -42,10 +27,15 @@ from .pretty import print_fail
 #         print_fail('The command is not specified or unrecognized.')
 
 
-@click.group(invoke_without_command=True)
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
+
+@click.group(invoke_without_command=True, context_settings=CONTEXT_SETTINGS)
 @click.version_option()
 @click.pass_context
 def main(ctx):
+    """Backend.AI command line interface.
+    """
     if ctx.invoked_subcommand is None:
         click.echo(main.get_help(ctx))
 
@@ -59,6 +49,7 @@ def _attach_command():
     from .manager import manager    # noqa
     from .proxy import proxy        # noqa
     from .ps import ps              # noqa
+    from .run import run, start, terminate, info # noqa
     from .vfolder import vfolder    # noqa
 
     main.add_command(admin)
@@ -71,6 +62,10 @@ def _attach_command():
     main.add_command(manager)
     main.add_command(proxy)
     main.add_command(ps)
+    main.add_command(run)
+    main.add_command(start)
+    main.add_command(terminate)
+    main.add_command(info)
     main.add_command(vfolder)
 
 

--- a/src/ai/backend/client/cli/__init__.py
+++ b/src/ai/backend/client/cli/__init__.py
@@ -70,8 +70,8 @@ def _attach_command():
     main.add_command(logs)
     main.add_command(manager)
     main.add_command(proxy)
-    # main.add_command(ps)
-    # main.add_command(vfolder)
+    main.add_command(ps)
+    main.add_command(vfolder)
 
 
 _attach_command()

--- a/src/ai/backend/client/cli/__init__.py
+++ b/src/ai/backend/client/cli/__init__.py
@@ -41,32 +41,7 @@ def main(ctx):
 
 
 def _attach_command():
-    from .admin import admin        # noqa
-    from .config import config      # noqa
-    from .app import app            # noqa
-    from .files import upload, download, ls     # noqa
-    from .logs import logs          # noqa
-    from .manager import manager    # noqa
-    from .proxy import proxy        # noqa
-    from .ps import ps              # noqa
-    from .run import run, start, terminate, info # noqa
-    from .vfolder import vfolder    # noqa
-
-    main.add_command(admin)
-    main.add_command(config)
-    main.add_command(app)
-    main.add_command(upload)
-    main.add_command(download)
-    main.add_command(ls)
-    main.add_command(logs)
-    main.add_command(manager)
-    main.add_command(proxy)
-    main.add_command(ps)
-    main.add_command(run)
-    main.add_command(start)
-    main.add_command(terminate)
-    main.add_command(info)
-    main.add_command(vfolder)
+    from . import admin, config, app, files, logs, manager, proxy, ps, run, vfolder
 
 
 _attach_command()

--- a/src/ai/backend/client/cli/__init__.py
+++ b/src/ai/backend/client/cli/__init__.py
@@ -1,6 +1,7 @@
-import click
+from pathlib import Path
+import sys
 
-from .pretty import print_fail
+import click
 
 
 class AliasGroup(click.Group):
@@ -101,21 +102,37 @@ class AliasGroup(click.Group):
 #         print_fail('The command is not specified or unrecognized.')
 
 
-CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
-
-
-@click.group(cls=AliasGroup, invoke_without_command=True, context_settings=CONTEXT_SETTINGS)
+@click.group(cls=AliasGroup,
+             context_settings=dict(help_option_names=['-h', '--help']))
 @click.version_option()
-@click.pass_context
-def main(ctx):
-    """Backend.AI command line interface.
+def main():
     """
-    if ctx.invoked_subcommand is None:
-        click.echo(main.get_help(ctx))
+    Backend.AI command line interface.
+    """
+
+
+@click.command(context_settings=dict(ignore_unknown_options=True,
+                                     allow_extra_args=True))
+@click.pass_context
+def run_alias(ctx):
+    """
+    Quick aliases for run command.
+    """
+    mode = Path(sys.argv[0]).stem
+    help = True if len(sys.argv) <= 1 else False
+    if mode == 'lcc':
+        sys.argv.insert(1, 'c')
+    elif mode == 'lpython':
+        sys.argv.insert(1, 'python')
+    sys.argv.insert(1, 'run')
+    if help:
+        sys.argv.append('--help')
+    main.main(prog_name='backend.ai')
 
 
 def _attach_command():
-    from . import admin, config, app, files, logs, manager, proxy, ps, run, vfolder
+    from . import admin, config, app, files, logs, manager, proxy, ps, run  # noqa
+    from . import vfolder       # noqa
 
 
 _attach_command()

--- a/src/ai/backend/client/cli/__init__.py
+++ b/src/ai/backend/client/cli/__init__.py
@@ -3,6 +3,80 @@ import click
 from .pretty import print_fail
 
 
+class AliasGroup(click.Group):
+    """
+    Enable command aliases.
+
+    ref) https://github.com/click-contrib/click-aliases
+    """
+    def __init__(self, *args, **kwargs):
+        super(AliasGroup, self).__init__(*args, **kwargs)
+        self._commands = {}
+        self._aliases = {}
+
+    def command(self, *args, **kwargs):
+        aliases = kwargs.pop('aliases', [])
+        decorator = super(AliasGroup, self).command(*args, **kwargs)
+        if not aliases:
+            return decorator
+
+        def _decorator(f):
+            cmd = decorator(f)
+            if aliases:
+                self._commands[cmd.name] = aliases
+                for alias in aliases:
+                    self._aliases[alias] = cmd.name
+            return cmd
+        return _decorator
+
+    def group(self, *args, **kwargs):
+        aliases = kwargs.pop('aliases', [])
+        decorator = super(AliasGroup, self).group(*args, **kwargs)
+        if not aliases:
+            return decorator
+
+        def _decorator(f):
+            cmd = decorator(f)
+            if aliases:
+                self._commands[cmd.name] = aliases
+                for alias in aliases:
+                    self._aliases[alias] = cmd.name
+            return cmd
+        return _decorator
+
+    def get_command(self, ctx, cmd_name):
+        if cmd_name in self._aliases:
+            cmd_name = self._aliases[cmd_name]
+        command = super(AliasGroup, self).get_command(ctx, cmd_name)
+        if command:
+            return command
+
+    def format_commands(self, ctx, formatter):
+        commands = []
+        for subcommand in self.list_commands(ctx):
+            cmd = self.get_command(ctx, subcommand)
+            # What is this, the tool lied about a command. Ignore it
+            if cmd is None:
+                continue
+            if cmd.hidden:
+                continue
+            if subcommand in self._commands:
+                aliases = ','.join(sorted(self._commands[subcommand]))
+                subcommand = '{0} ({1})'.format(subcommand, aliases)
+            commands.append((subcommand, cmd))
+
+        # allow for 3 times the default spacing
+        if len(commands):
+            limit = formatter.width - 6 - max(len(cmd[0]) for cmd in commands)
+            rows = []
+            for subcommand, cmd in commands:
+                help = cmd.get_short_help_str(limit)
+                rows.append((subcommand, help))
+            if rows:
+                with formatter.section('Commands'):
+                    formatter.write_dl(rows)
+
+
 # def main():
 
 #     if len(sys.argv) <= 1:
@@ -30,7 +104,7 @@ from .pretty import print_fail
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
-@click.group(invoke_without_command=True, context_settings=CONTEXT_SETTINGS)
+@click.group(cls=AliasGroup, invoke_without_command=True, context_settings=CONTEXT_SETTINGS)
 @click.version_option()
 @click.pass_context
 def main(ctx):

--- a/src/ai/backend/client/cli/admin/__init__.py
+++ b/src/ai/backend/client/cli/admin/__init__.py
@@ -1,4 +1,3 @@
-import click
 from .. import main
 
 

--- a/src/ai/backend/client/cli/admin/__init__.py
+++ b/src/ai/backend/client/cli/admin/__init__.py
@@ -1,9 +1,27 @@
-from .. import register_command
+import click
 
 
-@register_command
-def admin(args):
+@click.group()
+def admin():
     '''
     Provides the admin API access.
     '''
-    print('Run with -h/--help for usage.')
+
+
+def _attach_command():
+    from .agents import agent, agents               # noqa
+    from .keypairs import keypair, keypairs, add    # noqa
+    from .sessions import sessions, session         # noqa
+    from .vfolders import vfolders                  # noqa
+
+    admin.add_command(agent)
+    admin.add_command(agents)
+    admin.add_command(keypair)
+    admin.add_command(keypairs)
+    admin.add_command(add)
+    admin.add_command(session)
+    admin.add_command(sessions)
+    admin.add_command(vfolders)
+
+
+_attach_command()

--- a/src/ai/backend/client/cli/admin/__init__.py
+++ b/src/ai/backend/client/cli/admin/__init__.py
@@ -1,7 +1,8 @@
 import click
+from .. import main
 
 
-@click.group()
+@main.group()
 def admin():
     '''
     Provides the admin API access.
@@ -9,19 +10,7 @@ def admin():
 
 
 def _attach_command():
-    from .agents import agent, agents               # noqa
-    from .keypairs import keypair, keypairs, add    # noqa
-    from .sessions import sessions, session         # noqa
-    from .vfolders import vfolders                  # noqa
-
-    admin.add_command(agent)
-    admin.add_command(agents)
-    admin.add_command(keypair)
-    admin.add_command(keypairs)
-    admin.add_command(add)
-    admin.add_command(session)
-    admin.add_command(sessions)
-    admin.add_command(vfolders)
+    from . import agents, keypairs, sessions, vfolders  # noqa
 
 
 _attach_command()

--- a/src/ai/backend/client/cli/admin/agents.py
+++ b/src/ai/backend/client/cli/admin/agents.py
@@ -3,11 +3,12 @@ import sys
 import click
 from tabulate import tabulate
 
+from . import admin
 from ...session import Session
 from ..pretty import print_error
 
 
-@click.command()
+@admin.command()
 @click.option('-i', '--id', 'agent_id', required=True,
               help='The agent Id to inspect.')
 def agent(agent_id):
@@ -39,7 +40,7 @@ def agent(agent_id):
         print(tabulate(rows, headers=('Field', 'Value')))
 
 
-@click.command()
+@admin.command()
 @click.option('-s', '--status', type=str, default='ALIVE',
               help='Filter agents by the given status.')
 def agents(status):

--- a/src/ai/backend/client/cli/admin/agents.py
+++ b/src/ai/backend/client/cli/admin/agents.py
@@ -1,14 +1,16 @@
 import sys
 
+import click
 from tabulate import tabulate
 
 from ...session import Session
 from ..pretty import print_error
-from . import admin
 
 
-@admin.register_command
-def agent(args):
+@click.command()
+@click.option('-i', '--id', 'agent_id', required=True,
+              help='The agent Id to inspect.')
+def agent(agent_id):
     '''
     Show the information about the given agent.
     '''
@@ -26,7 +28,7 @@ def agent(args):
     ]
     with Session() as session:
         try:
-            agent = session.Agent(args.id)
+            agent = session.Agent(agent_id)
             info = agent.info(fields=(item[1] for item in fields))
         except Exception as e:
             print_error(e)
@@ -37,12 +39,10 @@ def agent(args):
         print(tabulate(rows, headers=('Field', 'Value')))
 
 
-agent.add_argument('-i', '--id', type=str, required=True,
-                   help='The agent ID to inspect.')
-
-
-@admin.register_command
-def agents(args):
+@click.command()
+@click.option('-s', '--status', type=str, default='ALIVE',
+              help='Filter agents by the given status.')
+def agents(status):
     '''
     List and manage agents.
     (admin privilege required)
@@ -61,8 +61,7 @@ def agents(args):
     ]
     with Session() as session:
         try:
-            items = session.Agent.list(args.status,
-                                       fields=(item[1] for item in fields))
+            items = session.Agent.list(status, fields=(item[1] for item in fields))
         except Exception as e:
             print_error(e)
             sys.exit(1)
@@ -71,7 +70,3 @@ def agents(args):
             return
         print(tabulate((item.values() for item in items),
                        headers=(item[0] for item in fields)))
-
-
-agents.add_argument('-s', '--status', type=str, default='ALIVE',
-                    help='Filter agents by the given status.')

--- a/src/ai/backend/client/cli/admin/keypairs.py
+++ b/src/ai/backend/client/cli/admin/keypairs.py
@@ -81,7 +81,6 @@ def keypairs(user_id, is_active):
                        headers=(item[0] for item in fields)))
 
 
-
 @admin.command()
 @click.argument('user-id', type=str, default=None, metavar='USERID')
 @click.option('-a', '--admin', is_flag=True,

--- a/src/ai/backend/client/cli/admin/keypairs.py
+++ b/src/ai/backend/client/cli/admin/keypairs.py
@@ -3,11 +3,12 @@ import sys
 import click
 from tabulate import tabulate
 
+from . import admin
 from ...session import Session
 from ..pretty import print_error, print_fail
 
 
-@click.command()
+@admin.command()
 def keypair():
     '''
     Show the server-side information of the currently configured access key.
@@ -37,7 +38,7 @@ def keypair():
         print(tabulate(rows, headers=('Field', 'Value')))
 
 
-@click.command()
+@admin.command()
 @click.option('-u', '--user-id', type=str, default=None,
               help='Show keypairs of this given user. [default: show all]')
 @click.option('--is-active', type=bool, default=None,
@@ -81,7 +82,7 @@ def keypairs(user_id, is_active):
 
 
 
-@click.command()
+@admin.command()
 @click.argument('user-id', type=str, default=None, metavar='USERID')
 @click.option('-a', '--admin', is_flag=True,
               help='Give the admin privilege to the new keypair.')

--- a/src/ai/backend/client/cli/admin/keypairs.py
+++ b/src/ai/backend/client/cli/admin/keypairs.py
@@ -82,8 +82,7 @@ def keypairs(user_id, is_active):
 
 
 @click.command()
-@click.option('-u', '--user-id', type=str, default=None,
-              help='Create a keypair for this user.')
+@click.argument('user-id', type=str, default=None, metavar='USERID')
 @click.option('-a', '--admin', is_flag=True,
               help='Give the admin privilege to the new keypair.')
 @click.option('-i', '--inactive', is_flag=True,
@@ -97,10 +96,9 @@ def keypairs(user_id, is_active):
 def add(user_id, admin, inactive, concurrency_limit, rate_limit, resource_policy):
     '''
     Add a new keypair.
+
+    USER_ID: User ID of a new key pair.
     '''
-    if user_id is None:
-        print('You must set the user ID (-u/--user-id).')
-        return
     try:
         user_id = int(user_id)
     except ValueError:

--- a/src/ai/backend/client/cli/admin/keypairs.py
+++ b/src/ai/backend/client/cli/admin/keypairs.py
@@ -1,14 +1,14 @@
 import sys
 
+import click
 from tabulate import tabulate
 
 from ...session import Session
 from ..pretty import print_error, print_fail
-from . import admin
 
 
-@admin.register_command
-def keypair(args):
+@click.command()
+def keypair():
     '''
     Show the server-side information of the currently configured access key.
     '''
@@ -37,8 +37,12 @@ def keypair(args):
         print(tabulate(rows, headers=('Field', 'Value')))
 
 
-@admin.register_command
-def keypairs(args):
+@click.command()
+@click.option('-u', '--user-id', type=str, default=None,
+              help='Show keypairs of this given user. [default: show all]')
+@click.option('--is-active', type=bool, default=None,
+              help='Filter keypairs by activation.')
+def keypairs(user_id, is_active):
     '''
     List and manage keypairs.
     To show all keypairs or other user's, your access key must have the admin
@@ -58,52 +62,58 @@ def keypairs(args):
         ('Concur.Limit', 'concurrency_limit'),
     ]
     try:
-        args.user_id = int(args.user_id)
+        user_id = int(user_id)
     except (TypeError, ValueError):
         pass  # string-based user ID for Backend.AI v1.4+
     with Session() as session:
         try:
-            items = session.KeyPair.list(args.user_id, args.is_active,
+            items = session.KeyPair.list(user_id, is_active,
                                          fields=(item[1] for item in fields))
         except Exception as e:
             print_error(e)
             sys.exit(1)
         if len(items) == 0:
             print('There are no matching keypairs associated '
-                  'with the user ID {0}'.format(args.user_id))
+                  'with the user ID {0}'.format(user_id))
             return
         print(tabulate((item.values() for item in items),
                        headers=(item[0] for item in fields)))
 
 
-keypairs.add_argument('-u', '--user-id', type=str, default=None,
-                      help='Show keypairs of this given user. '
-                           '[default: show all]')
-keypairs.add_argument('--is-active', type=bool, default=None,
-                      help='Filter keypairs by activation.')
 
-
-@keypairs.register_command
-def add(args):
+@click.command()
+@click.option('-u', '--user-id', type=str, default=None,
+              help='Create a keypair for this user.')
+@click.option('-a', '--admin', is_flag=True,
+              help='Give the admin privilege to the new keypair.')
+@click.option('-i', '--inactive', is_flag=True,
+              help='Create the new keypair in inactive state.')
+@click.option('-c', '--concurrency-limit', type=int, default=1,
+              help='Set the limit on concurrent sessions.')
+@click.option('-r', '--rate-limit', type=int, default=5000,
+              help='Set the API query rate limit.')
+@click.option('--resource-policy', type=str, default=None,
+              help='Set the resource policy. (reserved for future use)')
+def add(user_id, admin, inactive, concurrency_limit, rate_limit, resource_policy):
     '''
     Add a new keypair.
     '''
-    if args.user_id is None:
+    if user_id is None:
         print('You must set the user ID (-u/--user-id).')
         return
     try:
-        args.user_id = int(args.user_id)
+        user_id = int(user_id)
     except ValueError:
         pass  # string-based user ID for Backend.AI v1.4+
     with Session() as session:
         try:
             data = session.KeyPair.create(
-                args.user_id,
-                is_active=not args.inactive,
-                is_admin=args.admin,
-                resource_policy=args.resource_policy,
-                rate_limit=args.rate_limit,
-                concurrency_limit=args.concurrency_limit)
+                user_id,
+                is_active=not inactive,
+                is_admin=admin,
+                resource_policy=resource_policy,
+                rate_limit=rate_limit,
+                concurrency_limit=concurrency_limit)
         except Exception as e:
             print_error(e)
             sys.exit(1)
@@ -114,17 +124,3 @@ def add(args):
         item = data['keypair']
         print('Access Key: {0}'.format(item['access_key']))
         print('Secret Key: {0}'.format(item['secret_key']))
-
-
-add.add_argument('-u', '--user-id', type=str, default=None,
-                 help='Create a keypair for this user.')
-add.add_argument('-a', '--admin', action='store_true', default=False,
-                 help='Give the admin privilege to the new keypair.')
-add.add_argument('-i', '--inactive', action='store_true', default=False,
-                 help='Create the new keypair in inactive state.')
-add.add_argument('-c', '--concurrency-limit', type=int, default=1,
-                 help='Set the limit on concurrent sessions.')
-add.add_argument('-r', '--rate-limit', type=int, default=5000,
-                 help='Set the API query rate limit.')
-add.add_argument('--resource-policy', type=str, default=None,
-                 help='Set the resource policy. (reserved for future use)')

--- a/src/ai/backend/client/cli/admin/sessions.py
+++ b/src/ai/backend/client/cli/admin/sessions.py
@@ -3,11 +3,12 @@ import sys
 import click
 from tabulate import tabulate
 
+from . import admin
 from ...session import Session
 from ..pretty import print_error
 
 
-@click.command()
+@admin.command()
 @click.option('--status', default='RUNNING',
               type=click.Choice(['PREPARING', 'BUILDING', 'RUNNING', 'RESTARTING',
                                  'RESIZING', 'SUSPENDED', 'TERMINATING',
@@ -65,7 +66,7 @@ def sessions(status, access_key, id_only):
                            headers=(item[0] for item in fields)))
 
 
-@click.command()
+@admin.command()
 @click.argument('sess_id_or_alias', metavar='SESSID')
 def session(sess_id_or_alias):
     '''

--- a/src/ai/backend/client/cli/admin/sessions.py
+++ b/src/ai/backend/client/cli/admin/sessions.py
@@ -1,21 +1,30 @@
 import sys
 
+import click
 from tabulate import tabulate
 
 from ...session import Session
 from ..pretty import print_error
-from . import admin
 
 
-@admin.register_command
-def sessions(args):
+@click.command()
+@click.option('--status', default='RUNNING',
+              type=click.Choice(['PREPARING', 'BUILDING', 'RUNNING', 'RESTARTING',
+                                 'RESIZING', 'SUSPENDED', 'TERMINATING',
+                                 'TERMINATED', 'ERROR', 'ALL']),
+              help='Filter by the given status')
+@click.option('--access-key', type=str, default=None,
+              help='Get sessions for a specific access key '
+                   '(only works if you are a super-admin)')
+@click.option('--id-only', is_flag=True, help='Display session ids only.')
+def sessions(status, access_key, id_only):
     '''
     List and manage compute sessions.
     '''
     fields = [
         ('Session ID', 'sess_id'),
     ]
-    if not args.id_only:
+    if not id_only:
         fields.extend([
             ('Lang/runtime', 'lang'),
             ('Tag', 'tag'),
@@ -26,7 +35,7 @@ def sessions(args):
             ('CPU Slot', 'cpu_slot'),
             ('GPU Slot', 'gpu_slot'),
         ])
-    if args.access_key is None:
+    if access_key is None:
         q = 'query($status:String) {' \
             '  compute_sessions(status:$status) { $fields }' \
             '}'
@@ -36,8 +45,8 @@ def sessions(args):
             '}'
     q = q.replace('$fields', ' '.join(item[1] for item in fields))
     v = {
-        'status': args.status if args.status != 'ALL' else None,
-        'ak': args.access_key,
+        'status': status if status != 'ALL' else None,
+        'ak': access_key,
     }
     with Session() as session:
         try:
@@ -48,7 +57,7 @@ def sessions(args):
         if len(resp['compute_sessions']) == 0:
             print('There are no compute sessions currently running.')
             return
-        if args.id_only:
+        if id_only:
             for item in resp['compute_sessions']:
                 print(item['sess_id'])
         else:
@@ -56,22 +65,12 @@ def sessions(args):
                            headers=(item[0] for item in fields)))
 
 
-sessions.add_argument('--status', type=str, default='RUNNING',
-                      choices={'PREPARING', 'BUILDING', 'RUNNING',
-                               'RESTARTING', 'RESIZING', 'SUSPENDED',
-                               'TERMINATING', 'TERMINATED', 'ERROR', 'ALL'},
-                      help='Filter by the given status')
-sessions.add_argument('--access-key', type=str, default=None,
-                      help='Get sessions for a specific access key '
-                           '(only works if you are a super-admin)')
-sessions.add_argument('--id-only', action='store_true', default=False,
-                      help='Display session ids only.')
-
-
-@admin.register_command
-def session(args):
+@click.command()
+@click.argument('sess_id_or_alias', metavar='NAME')
+def session(sess_id_or_alias):
     '''
-    Show detailed information for a running compute session.
+    Show detailed information for a running compute session. NAME is session id or
+    its alias.
     '''
     fields = [
         ('Session ID', 'sess_id'),
@@ -101,7 +100,7 @@ def session(args):
         '  compute_session(sess_id:$sess_id) { $fields }' \
         '}'
     q = q.replace('$fields', ' '.join(item[1] for item in fields))
-    v = {'sess_id': args.sess_id_or_alias}
+    v = {'sess_id': sess_id_or_alias}
     with Session() as session:
         try:
             resp = session.Admin.query(q, v)
@@ -114,8 +113,3 @@ def session(args):
         print('Session detail:\n---------------')
         for i, value in enumerate(resp['compute_session'].values()):
             print(fields[i][0] + ': ' + str(value))
-
-
-session.add_argument('sess_id_or_alias', metavar='NAME',
-                     help='The session ID or its alias '
-                          'given when creating the session.')

--- a/src/ai/backend/client/cli/admin/sessions.py
+++ b/src/ai/backend/client/cli/admin/sessions.py
@@ -66,11 +66,12 @@ def sessions(status, access_key, id_only):
 
 
 @click.command()
-@click.argument('sess_id_or_alias', metavar='NAME')
+@click.argument('sess_id_or_alias', metavar='SESSID')
 def session(sess_id_or_alias):
     '''
-    Show detailed information for a running compute session. NAME is session id or
-    its alias.
+    Show detailed information for a running compute session.
+
+    SESSID: Session id or its alias.
     '''
     fields = [
         ('Session ID', 'sess_id'),

--- a/src/ai/backend/client/cli/admin/vfolders.py
+++ b/src/ai/backend/client/cli/admin/vfolders.py
@@ -1,14 +1,17 @@
 import sys
 
+import click
 from tabulate import tabulate
 
 from ...session import Session
 from ..pretty import print_error
-from . import admin
 
 
-@admin.register_command
-def vfolders(args):
+@click.command()
+@click.option('--access-key', type=str, default=None,
+              help='Get vfolders for the given access key '
+                   '(only works if you are a super-admin)')
+def vfolders(access_key):
     '''
     List and manage virtual folders.
     '''
@@ -19,7 +22,7 @@ def vfolders(args):
         ('Max Files', 'max_files'),
         ('Max Size', 'max_size'),
     ]
-    if args.access_key is None:
+    if access_key is None:
         q = 'query { vfolders { $fields } }'
     else:
         q = 'query($ak:String) { vfolders(access_key:$ak) { $fields } }'
@@ -32,8 +35,3 @@ def vfolders(args):
             sys.exit(1)
         print(tabulate((item.values() for item in resp['vfolders']),
                        headers=(item[0] for item in fields)))
-
-
-vfolders.add_argument('--access-key', type=str, default=None,
-                      help='Get vfolders for the given access key '
-                           '(only works if you are a super-admin)')

--- a/src/ai/backend/client/cli/admin/vfolders.py
+++ b/src/ai/backend/client/cli/admin/vfolders.py
@@ -3,11 +3,12 @@ import sys
 import click
 from tabulate import tabulate
 
+from . import admin
 from ...session import Session
 from ..pretty import print_error
 
 
-@click.command()
+@admin.command()
 @click.option('--access-key', type=str, default=None,
               help='Get vfolders for the given access key '
                    '(only works if you are a super-admin)')

--- a/src/ai/backend/client/cli/app.py
+++ b/src/ai/backend/client/cli/app.py
@@ -1,11 +1,10 @@
 import asyncio
 import aiohttp
+import click
 from ..request import Request
 from ..session import AsyncSession
 from ..compat import token_hex
 from .pretty import print_info
-
-from . import register_command
 
 
 class WSProxy:
@@ -95,14 +94,18 @@ class ProxyRunner:
         await self.session.close()
 
 
-@register_command
-def app(args):
+@click.command()
+@click.argument('app')
+@click.option('--bind', type=str, default='localhost',
+              help='The IP/host address to bind this proxy.')
+@click.option('-p', '--port', type=int, default=8080,
+              help='The TCP port to accept non-encrypted non-authorized API requests.')
+def app(app, bind, port):
     """
-    Run the web app via backend.ai
+    Run the web app via backend.ai. APP can be run via http (BETA).
     """
-
     loop = asyncio.get_event_loop()
-    r = ProxyRunner(args.app, args.bind, args.port, loop)
+    r = ProxyRunner(app, bind, port, loop)
     loop.run_until_complete(r.ready())
     try:
         loop.run_forever()
@@ -111,12 +114,3 @@ def app(args):
     print_info("Shutting down....")
     loop.run_until_complete(r.close())
     print_info("Done")
-
-
-app.add_argument('app',
-                 help='Run an app via http (BETA)')
-app.add_argument('--bind', type=str, default='localhost',
-                   help='The IP/host address to bind this proxy.')
-app.add_argument('-p', '--port', type=int, default=8080,
-                   help='The TCP port to accept non-encrypted non-authorized '
-                        'API requests.')

--- a/src/ai/backend/client/cli/app.py
+++ b/src/ai/backend/client/cli/app.py
@@ -4,6 +4,7 @@ import signal
 import aiohttp
 import click
 
+from . import main
 from .pretty import print_info, print_error
 from ..request import Request
 from ..session import AsyncSession
@@ -115,7 +116,7 @@ class ProxyRunner:
         await self.local_server.wait_closed()
 
 
-@click.command()
+@main.command()
 @click.argument('session_id', type=str, metavar='SESSID')
 @click.argument('app', type=str)
 @click.option('--bind', type=str, default='127.0.0.1',

--- a/src/ai/backend/client/cli/app.py
+++ b/src/ai/backend/client/cli/app.py
@@ -116,8 +116,7 @@ class ProxyRunner:
 
 
 @click.command()
-@click.argument('session_id', type=str, metavar='SESSID',
-                help='The compute session ID.')
+@click.argument('session_id', type=str, metavar='SESSID')
 @click.argument('app', type=str)
 @click.option('--bind', type=str, default='127.0.0.1',
               help='The IP/host address to bind this proxy.')
@@ -129,6 +128,7 @@ def app(session_id, app, bind, port):
 
     The type of proxy depends on the app definition: plain TCP or HTTP.
 
+    \b
     SESSID: The compute session ID.
     APP: The name of service provided by the given session.
     """

--- a/src/ai/backend/client/cli/config.py
+++ b/src/ai/backend/client/cli/config.py
@@ -2,8 +2,6 @@ from . import main
 from .. import __version__
 from ..config import get_config
 
-import click
-
 
 @main.command()
 def config():

--- a/src/ai/backend/client/cli/config.py
+++ b/src/ai/backend/client/cli/config.py
@@ -1,10 +1,11 @@
+from . import main
 from .. import __version__
 from ..config import get_config
 
 import click
 
 
-@click.command()
+@main.command()
 def config():
     '''
     Shows the current configuration.

--- a/src/ai/backend/client/cli/config.py
+++ b/src/ai/backend/client/cli/config.py
@@ -1,10 +1,11 @@
-from . import register_command
 from .. import __version__
 from ..config import get_config
 
+import click
 
-@register_command
-def config(args):
+
+@click.command()
+def config():
     '''
     Shows the current configuration.
     '''

--- a/src/ai/backend/client/cli/files.py
+++ b/src/ai/backend/client/cli/files.py
@@ -15,9 +15,14 @@ from ..session import Session
 @click.argument('files', type=click.Path(exists=True), nargs=-1)
 def upload(sess_id_or_alias, files):
     """
-    Upload files to user's home folder. SESSID is the session ID or its alias given
-    when creating the session. FILES are the paths to upload.
+    Upload files to user's home folder.
+
+    \b
+    SESSID: Session ID or its alias given when creating the session.
+    FILES: Path to upload.
     """
+    if len(files) < 1:
+        return
     with Session() as session:
         try:
             print_wait('Uploading files...')
@@ -36,9 +41,14 @@ def upload(sess_id_or_alias, files):
               help='Destination path to store downloaded file(s)')
 def download(sess_id_or_alias, files, dest):
     """
-    Download files from a running container. SESSID is the session ID or its alias
-    given when creating the session. FILES are paths inside container.
+    Download files from a running container.
+
+    \b
+    SESSID: Session ID or its alias given when creating the session.
+    FILES: Paths inside container.
     """
+    if len(files) < 1:
+        return
     with Session() as session:
         try:
             print_wait('Downloading file(s) from {}...'
@@ -56,8 +66,11 @@ def download(sess_id_or_alias, files, dest):
 @click.argument('path', metavar='PATH', nargs=1, default='/home/work')
 def ls(sess_id_or_alias, path):
     """
-    List files in a path of a running container. SESSID is the session ID or its
-    alias given when creating the session. PATH is the path inside container.
+    List files in a path of a running container.
+
+    \b
+    SESSID: Session ID or its alias given when creating the session.
+    PATH: Path inside container.
     """
     with Session() as session:
         try:

--- a/src/ai/backend/client/cli/files.py
+++ b/src/ai/backend/client/cli/files.py
@@ -3,71 +3,67 @@ import json
 from pathlib import Path
 import sys
 
+import click
 from tabulate import tabulate
 
-from . import register_command
 from .pretty import print_wait, print_done, print_error, print_fail
 from ..session import Session
 
 
-@register_command
-def upload(args):
+@click.command()
+@click.argument('sess_id_or_alias', metavar='SESSID')
+@click.argument('files', type=click.Path(exists=True), nargs=-1)
+def upload(sess_id_or_alias, files):
     """
-    Upload files to user's home folder.
+    Upload files to user's home folder. SESSID is the session ID or its alias given
+    when creating the session. FILES are the paths to upload.
     """
     with Session() as session:
         try:
             print_wait('Uploading files...')
-            kernel = session.Kernel(args.sess_id_or_alias)
-            kernel.upload(args.files, show_progress=True)
+            kernel = session.Kernel(sess_id_or_alias)
+            kernel.upload(files, show_progress=True)
             print_done('Uploaded.')
         except Exception as e:
             print_error(e)
             sys.exit(1)
 
 
-upload.add_argument('sess_id_or_alias', metavar='NAME',
-                    help=('The session ID or its alias given when creating the'
-                          'session.'))
-upload.add_argument('files', type=Path, nargs='+', help='File paths to upload.')
-
-
-@register_command
-def download(args):
+@click.command()
+@click.argument('sess_id_or_alias', metavar='SESSID')
+@click.argument('files', nargs=-1)
+@click.option('--dest', type=Path, default='.',
+              help='Destination path to store downloaded file(s)')
+def download(sess_id_or_alias, files, dest):
     """
-    Download files from a running container.
+    Download files from a running container. SESSID is the session ID or its alias
+    given when creating the session. FILES are paths inside container.
     """
     with Session() as session:
         try:
             print_wait('Downloading file(s) from {}...'
-                       .format(args.sess_id_or_alias))
-            kernel = session.Kernel(args.sess_id_or_alias)
-            kernel.download(args.files, args.dest, show_progress=True)
-            print_done('Downloaded to {}.'.format(args.dest.resolve()))
+                       .format(sess_id_or_alias))
+            kernel = session.Kernel(sess_id_or_alias)
+            kernel.download(files, dest, show_progress=True)
+            print_done('Downloaded to {}.'.format(dest.resolve()))
         except Exception as e:
             print_error(e)
             sys.exit(1)
 
 
-download.add_argument('sess_id_or_alias', metavar='NAME',
-                      help=('The session ID or its alias given when creating the'
-                            'session.'))
-download.add_argument('files', nargs='+',
-                      help='File paths inside container')
-download.add_argument('--dest', type=Path, default='.',
-                      help='Destination path to store downloaded file(s)')
-
-
-@register_command
-def ls(args):
+@click.command()
+@click.argument('sess_id_or_alias', metavar='SESSID')
+@click.argument('path', metavar='PATH', nargs=1, default='/home/work')
+def ls(sess_id_or_alias, path):
     """
-    List files in a path of a running container.
+    List files in a path of a running container. SESSID is the session ID or its
+    alias given when creating the session. PATH is the path inside container.
     """
     with Session() as session:
         try:
-            print_wait('Retrieving list of files in "{}"...'.format(args.path))
-            kernel = session.Kernel(args.sess_id_or_alias)
-            result = kernel.list_files(args.path)
+            print_wait('Retrieving list of files in "{}"...'.format(path))
+            kernel = session.Kernel(sess_id_or_alias)
+            result = kernel.list_files(path)
 
             if 'errors' in result and result['errors']:
                 print_fail(result['errors'])
@@ -87,9 +83,3 @@ def ls(args):
         except Exception as e:
             print_error(e)
             sys.exit(1)
-
-
-ls.add_argument('sess_id_or_alias', metavar='SESSID',
-                help='The session ID or its alias given when creating the session.')
-ls.add_argument('path', metavar='PATH', nargs='?', default='/home/work',
-                help='Path inside container')

--- a/src/ai/backend/client/cli/files.py
+++ b/src/ai/backend/client/cli/files.py
@@ -6,11 +6,12 @@ import sys
 import click
 from tabulate import tabulate
 
+from . import main
 from .pretty import print_wait, print_done, print_error, print_fail
 from ..session import Session
 
 
-@click.command()
+@main.command()
 @click.argument('sess_id_or_alias', metavar='SESSID')
 @click.argument('files', type=click.Path(exists=True), nargs=-1)
 def upload(sess_id_or_alias, files):
@@ -34,7 +35,7 @@ def upload(sess_id_or_alias, files):
             sys.exit(1)
 
 
-@click.command()
+@main.command()
 @click.argument('sess_id_or_alias', metavar='SESSID')
 @click.argument('files', nargs=-1)
 @click.option('--dest', type=Path, default='.',
@@ -61,7 +62,7 @@ def download(sess_id_or_alias, files, dest):
             sys.exit(1)
 
 
-@click.command()
+@main.command()
 @click.argument('sess_id_or_alias', metavar='SESSID')
 @click.argument('path', metavar='PATH', nargs=1, default='/home/work')
 def ls(sess_id_or_alias, path):

--- a/src/ai/backend/client/cli/logs.py
+++ b/src/ai/backend/client/cli/logs.py
@@ -2,11 +2,12 @@ import sys
 
 import click
 
+from . import main
 from .pretty import print_wait, print_done, print_error
 from ..session import Session
 
 
-@click.command()
+@main.command()
 @click.argument('sess_id_or_alias', metavar='SESSID')
 def logs(sess_id_or_alias):
     '''

--- a/src/ai/backend/client/cli/logs.py
+++ b/src/ai/backend/client/cli/logs.py
@@ -1,19 +1,22 @@
 import sys
 
-from . import register_command
+import click
+
 from .pretty import print_wait, print_done, print_error
 from ..session import Session
 
 
-@register_command
-def logs(args):
+@click.command()
+@click.argument('sess_id_or_alias', metavar='SESSID')
+def logs():
     '''
-    Shows the output logs of a running container.
+    Shows the output logs of a running container. The session ID or its alias given
+    when creating the session.
     '''
     with Session() as session:
         try:
             print_wait('Retrieving container logs...')
-            kernel = session.Kernel(args.sess_id_or_alias)
+            kernel = session.Kernel(sess_id_or_alias)
             result = kernel.get_logs().get('result')
             logs = result.get('logs') if 'logs' in result else ''
             print(logs)
@@ -21,8 +24,3 @@ def logs(args):
         except Exception as e:
             print_error(e)
             sys.exit(1)
-
-
-logs.add_argument('sess_id_or_alias', metavar='NAME',
-                  help='The session ID or its alias '
-                       'given when creating the session.')

--- a/src/ai/backend/client/cli/logs.py
+++ b/src/ai/backend/client/cli/logs.py
@@ -8,10 +8,12 @@ from ..session import Session
 
 @click.command()
 @click.argument('sess_id_or_alias', metavar='SESSID')
-def logs():
+def logs(sess_id_or_alias):
     '''
-    Shows the output logs of a running container. The session ID or its alias given
-    when creating the session.
+    Shows the output logs of a running container.
+
+    \b
+    SESSID: Session ID or its alias given when creating the session.
     '''
     with Session() as session:
         try:

--- a/src/ai/backend/client/cli/manager.py
+++ b/src/ai/backend/client/cli/manager.py
@@ -1,21 +1,21 @@
 import sys
 import time
 
+import click
 from tabulate import tabulate
 
-from . import register_command
 from .pretty import print_wait, print_done
 from ..session import Session
 
 
-@register_command
-def manager(args):
+@click.group()
+def manager():
     '''Provides manager-related operations.'''
     print('Run with -h/--help for usage.')
 
 
-@manager.register_command
-def status(args):
+@manager.command()
+def status():
     '''Show the manager's current status.'''
     with Session() as session:
         resp = session.Manager.status()
@@ -24,16 +24,21 @@ def status(args):
                        headers='firstrow'))
 
 
-@manager.register_command
-def freeze(args):
+@manager.command()
+@click.option('--wait', is_flag=True,
+              help='Hold up freezing the manager until '
+                   'there are no running sessions in the manager.')
+@click.option('--force-kill', is_flag=True,
+              help='Kill all running sessions immediately and freeze the manager.')
+def freeze(wait, force_kill):
     '''Freeze manager.'''
-    if args.wait and args.force_kill:
+    if wait and force_kill:
         print('You cannot use both --wait and --force-kill options '
               'at the same time.', file=sys.stderr)
         return
 
     with Session() as session:
-        if args.wait:
+        if wait:
             while True:
                 resp = session.Manager.status()
                 active_sessions_num = resp['active_sessions']
@@ -44,28 +49,19 @@ def freeze(args):
                 time.sleep(3)
             print_done('All sessions are terminated.')
 
-        if args.force_kill:
+        if force_kill:
             print_wait('Killing all sessions...')
 
-        session.Manager.freeze(force_kill=args.force_kill)
+        session.Manager.freeze(force_kill=force_kill)
 
-        if args.force_kill:
+        if force_kill:
             print_done('All sessions are killed.')
 
         print('Manager is successfully frozen.')
 
 
-freeze.add_argument('--wait', action='store_true', default=False,
-                    help='Hold up freezing the manager until '
-                         'there are no running sessions in the manager.')
-
-freeze.add_argument('--force-kill', action='store_true', default=False,
-                    help='Kill all running sessions immediately '
-                         'and freeze the manager.')
-
-
-@manager.register_command
-def unfreeze(args):
+@manager.command()
+def unfreeze():
     '''Unfreeze manager.'''
     with Session() as session:
         session.Manager.unfreeze()

--- a/src/ai/backend/client/cli/manager.py
+++ b/src/ai/backend/client/cli/manager.py
@@ -4,11 +4,12 @@ import time
 import click
 from tabulate import tabulate
 
+from . import main
 from .pretty import print_wait, print_done
 from ..session import Session
 
 
-@click.group()
+@main.group()
 def manager():
     '''Provides manager-related operations.'''
     print('Run with -h/--help for usage.')

--- a/src/ai/backend/client/cli/proxy.py
+++ b/src/ai/backend/client/cli/proxy.py
@@ -5,6 +5,7 @@ import aiohttp
 from aiohttp import web
 import click
 
+from . import main
 from .pretty import print_info, print_error, print_fail
 from ..exceptions import BackendAPIError, BackendClientError
 from ..request import Request
@@ -180,7 +181,7 @@ async def cleanup_proxy(app):
     await app['client_session'].close()
 
 
-@click.command(context_settings=dict(allow_extra_args=True))
+@main.command(context_settings=dict(allow_extra_args=True))
 @click.option('--bind', type=str, default='localhost',
               help='The IP/host address to bind this proxy.')
 @click.option('-p', '--port', type=int, default=8084,

--- a/src/ai/backend/client/cli/proxy.py
+++ b/src/ai/backend/client/cli/proxy.py
@@ -5,8 +5,8 @@ import sys
 import aiohttp
 from aiohttp import web
 from aiohttp.client_exceptions import ClientResponseError, ClientConnectorError
+import click
 
-from . import register_command
 from .pretty import print_info, print_error, print_fail
 from ..exceptions import BackendAPIError, BackendClientError
 from ..request import Request
@@ -182,8 +182,14 @@ async def cleanup_proxy(app):
     await app['client_session'].close()
 
 
-@register_command
-def proxy(args):
+@click.command(context_settings=dict(allow_extra_args=True))
+@click.option('--bind', type=str, default='localhost',
+              help='The IP/host address to bind this proxy.')
+@click.option('-p', '--port', type=int, default=8084,
+              help='The TCP port to accept non-encrypted non-authorized '
+                   'API requests.')
+@click.pass_context
+def proxy(ctx, bind, port):
     """
     Run a non-encrypted non-authorized API proxy server.
     Use this only for development and testing!
@@ -195,13 +201,6 @@ def proxy(args):
     app.router.add_route("GET", r'/stream/{path:.*$}', websocket_handler)
     app.router.add_route("GET", r'/wsproxy/{path:.*$}', websocket_handler)
     app.router.add_route('*', r'/{path:.*$}', web_handler)
-    if getattr(args, 'testing', False):
+    if getattr(ctx.args, 'testing', False):
         return app
-    web.run_app(app, host=args.bind, port=args.port)
-
-
-proxy.add_argument('--bind', type=str, default='localhost',
-                   help='The IP/host address to bind this proxy.')
-proxy.add_argument('-p', '--port', type=int, default=8084,
-                   help='The TCP port to accept non-encrypted non-authorized '
-                        'API requests.')
+    web.run_app(app, host=bind, port=port)

--- a/src/ai/backend/client/cli/ps.py
+++ b/src/ai/backend/client/cli/ps.py
@@ -2,10 +2,11 @@ from argparse import Namespace
 
 import click
 
+from . import main
 from .admin.sessions import sessions
 
 
-@click.command()
+@main.command()
 @click.option('--id-only', is_flag=True, help='Display session ids only.')
 @click.pass_context
 def ps(ctx, id_only):

--- a/src/ai/backend/client/cli/ps.py
+++ b/src/ai/backend/client/cli/ps.py
@@ -1,21 +1,16 @@
 from argparse import Namespace
 
-from . import register_command
+import click
+
 from .admin.sessions import sessions
 
 
-@register_command
-def ps(args):
+@click.command()
+@click.option('--id-only', is_flag=True, help='Display session ids only.')
+@click.pass_context
+def ps(ctx, id_only):
     '''
     Lists the current running compute sessions for the current keypair.
     This is an alias of the "admin sessions --status=RUNNING" command.
     '''
-    inner_args = Namespace()
-    inner_args.status = 'RUNNING'
-    inner_args.access_key = None
-    inner_args.id_only = args.id_only
-    sessions(inner_args)
-
-
-ps.add_argument('--id-only', action='store_true', default=False,
-                help='Display session ids only.')
+    ctx.forward(sessions)

--- a/src/ai/backend/client/cli/ps.py
+++ b/src/ai/backend/client/cli/ps.py
@@ -1,5 +1,3 @@
-from argparse import Namespace
-
 import click
 
 from . import main

--- a/src/ai/backend/client/cli/run.py
+++ b/src/ai/backend/client/cli/run.py
@@ -390,8 +390,6 @@ def run(lang, files, session_id, cluster_size, code, clean, build, exec, termina
     def _run_legacy(session, idx, session_id, envs,
                     clean_cmd, build_cmd, exec_cmd):
         try:
-            print('######')
-            print(mount)
             kernel = session.Kernel.get_or_create(
                 lang,
                 client_token=session_id,
@@ -400,7 +398,6 @@ def run(lang, files, session_id, cluster_size, code, clean, build, exec, termina
                 envs=envs,
                 resources=resources,
                 tag=tag)
-            print('######')
         except Exception as e:
             print_error(e)
             sys.exit(1)
@@ -448,10 +445,10 @@ def run(lang, files, session_id, cluster_size, code, clean, build, exec, termina
                 ret = kernel.destroy()
                 vprint_done('[{0}] Cleaned up the session.'.format(idx))
                 if stats:
-                    stats = ret.get('stats', None) if ret else None
-                    if stats:
+                    _stats = ret.get('stats', None) if ret else None
+                    if _stats:
                         print('[{0}] Statistics:\n{1}'
-                              .format(idx, _format_stats(stats)))
+                              .format(idx, _format_stats(_stats)))
                     else:
                         print('[{0}] Statistics is not available.'.format(idx))
 
@@ -533,9 +530,9 @@ def run(lang, files, session_id, cluster_size, code, clean, build, exec, termina
                     ret = await kernel.destroy()
                     vprint_done('[{0}] Cleaned up the session.'.format(idx))
                     if stats:
-                        stats = ret.get('stats', None) if ret else None
-                        if stats:
-                            stats_str = _format_stats(stats)
+                        _stats = ret.get('stats', None) if ret else None
+                        if _stats:
+                            stats_str = _format_stats(_stats)
                             print(format_info('[{0}] Statistics:'.format(idx)) +
                                   '\n{0}'.format(stats_str))
                             if is_multi:

--- a/src/ai/backend/client/cli/run.py
+++ b/src/ai/backend/client/cli/run.py
@@ -1,4 +1,4 @@
-from argparse import ArgumentTypeError, Namespace
+from argparse import ArgumentTypeError
 import asyncio
 import collections
 from decimal import Decimal
@@ -253,7 +253,6 @@ def _prepare_mount_arg(mount):
 
 
 @main.command()
-@click.pass_context
 @click.argument('lang', type=str)
 @click.argument('files', nargs=-1, type=click.Path())
 @click.option('-t', '--session-id', '--client-token', metavar='SESSID',
@@ -303,9 +302,9 @@ def _prepare_mount_arg(mount):
 @click.option('--legacy', is_flag=True,
               help='Use the legacy synchronous polling mode to '
                    'fetch console outputs.')
-def run(ctx, lang, files, session_id, cluster_size, code, clean, build, exec,
-        terminal, basedir, rm, env, env_range, build_range, exec_range, max_parallel,
-        mount, stats, tag, resources, quiet, legacy):
+def run(lang, files, session_id, cluster_size, code, clean, build, exec, terminal,
+        basedir, rm, env, env_range, build_range, exec_range, max_parallel, mount,
+        stats, tag, resources, quiet, legacy):
     '''
     Run the given code snippet or files in a session.
     Depending on the session ID you give (default is random),
@@ -630,7 +629,7 @@ def run(ctx, lang, files, session_id, cluster_size, code, clean, build, exec,
                    'The unit of mem(ory) is MiB.')
 @click.option('--cluster-size', metavar='NUMBER', type=int, default=1,
               help='The size of cluster in number of containers.')
-def start(lang, session_id, env, mount, resources, cluster_size):
+def start(lang, session_id, env, mount, tag, resources, cluster_size):
     '''
     Prepare and start a single compute session without executing codes.
     You may use the created session to execute codes using the "run" command

--- a/src/ai/backend/client/cli/run.py
+++ b/src/ai/backend/client/cli/run.py
@@ -16,6 +16,7 @@ import click
 from humanize import naturalsize
 from tabulate import tabulate
 
+from . import main
 from .admin.sessions import session
 from ..compat import current_loop, token_hex
 from ..exceptions import BackendError
@@ -251,7 +252,7 @@ def _prepare_mount_arg(mount):
     return list(mount)
 
 
-@click.command()
+@main.command()
 @click.pass_context
 @click.argument('lang', type=str)
 @click.argument('files', nargs=-1, type=click.Path())
@@ -610,7 +611,7 @@ def run(ctx, lang, files, session_id, cluster_size, code, clean, build, exec,
             loop.close()
 
 
-@click.command()
+@main.command()
 @click.pass_context
 @click.argument('lang')
 @click.option('-t', '--session-id', '--client-token', metavar='SESSID',
@@ -672,7 +673,7 @@ def start(lang, session_id, env, mount, resources, cluster_size):
 
 
 # @click.command(aliases=['rm', 'kill'])
-@click.command()
+@main.command()
 @click.argument('sess_id_or_alias', metavar='SESSID', nargs=-1)
 @click.option('-s', '--stats', is_flag=True,
               help='Show resource usage statistics after termination')

--- a/src/ai/backend/client/cli/run.py
+++ b/src/ai/backend/client/cli/run.py
@@ -672,8 +672,7 @@ def start(lang, session_id, env, mount, resources, cluster_size):
                            .format(session_id))
 
 
-# @click.command(aliases=['rm', 'kill'])
-@main.command()
+@main.command(aliases=['rm', 'kill'])
 @click.argument('sess_id_or_alias', metavar='SESSID', nargs=-1)
 @click.option('-s', '--stats', is_flag=True,
               help='Show resource usage statistics after termination')

--- a/src/ai/backend/client/cli/run.py
+++ b/src/ai/backend/client/cli/run.py
@@ -11,10 +11,10 @@ import string
 import sys
 
 import aiohttp
+import click
 from humanize import naturalsize
 from tabulate import tabulate
 
-from . import register_command
 from .admin.sessions import session
 from ..compat import current_loop, token_hex
 from ..exceptions import BackendError
@@ -221,33 +221,87 @@ def _get_mem_slots(memslot):
     return mod_size
 
 
-@register_command
-def run(args):
+@click.command()
+@click.argument('lang')
+@click.argument('files', nargs=-1, type=click.Path())
+@click.option('-t', '--session-id', '--client-token', metavar='SESSID',
+              help='Specify a human-readable session ID or name. '
+                   'If not set, a random hex string is used.')
+@click.option('--cluster-size', metavar='NUMBER', type=int, default=1,
+              help='The size of cluster in number of containers.')
+@click.option('-c', '--code', metavar='CODE',
+              help='The code snippet as a single string')
+@click.option('--clean', metavar='CMD',
+              help='Custom shell command for cleaning up the base directory')
+@click.option('--build', metavar='CMD',
+              help='Custom shell command for building the given files')
+@click.option('--exec', metavar='CMD',
+              help='Custom shell command for executing the given files')
+@click.option('--terminal', is_flag=True,
+              help='Connect to the terminal-type kernel.')
+@click.option('--basedir', metavar='PATH', type=click.Path(), default=None,
+              help='Base directory path of uploaded files. '
+                   'All uploaded files must reside inside this directory.')
+@click.option('--rm', is_flag=True,
+              help='Terminate the session immediately after running '
+                   'the given code or files')
+@click.option('-e', '--env', metavar='KEY=VAL', type=str, action='append',
+              help='Environment variable (may appear multiple times)')
+@click.option('--env-range', metavar='RANGE_EXPR', action='append',
+              type=range_expr, help='Range expression for environment variable.')
+@click.option('--build-range', metavar='RANGE_EXPR', action='append',
+              type=range_expr, help='Range expression for execution arguments.')
+@click.option('--exec-range', metavar='RANGE_EXPR', action='append', type=range_expr,
+              help='Range expression for execution arguments.')
+@click.option('--max-parallel', metavar='NUM', type=int, default=2,
+              help='The maximum number of parallel sessions.')
+@click.option('-m', '--mount', type=str, action='append',
+              help='User-owned virtual folder names to mount')
+@click.option('-s', '--stats', is_flag=True,
+              help='Show resource usage statistics after termination '
+                   '(only works if "--rm" is given)')
+@click.option('--tag', type=str, default=None,
+              help='User-defined tag string to annotate sessions.')
+@click.option('-r', '--resources', metavar='KEY=VAL', type=str, action='append',
+              help='Set computation resources (e.g: -r cpu=2 -r mem=256 -r gpu=1)'
+                   '. 1 slot of cpu/gpu represents 1 core. The unit of mem(ory) '
+                   'is MiB.')
+@click.option('-q', '--quiet', if_flag=True,
+              help='Hide execution details but show only the kernel outputs.')
+@click.option('--legacy', is_flag=True,
+              help='Use the legacy synchronous polling mode to '
+                   'fetch console outputs.')
+def run(lang, files, session_id, cluster_size, code, clean, build, exec, terminal,
+        basedir, rm, env, env_range, build_range, exec_range, max_parallel, mount,
+        stats, tag, resources, quiet, legacy):
     '''
     Run the given code snippet or files in a session.
     Depending on the session ID you give (default is random),
     it may reuse an existing session or create a new one.
+
+    LANG: The runtime or programming language name.
+    FILES: The code file(s). Can be added multiple times.
     '''
-    if args.quiet:
+    if quiet:
         vprint_info = vprint_wait = vprint_done = _noop
     else:
         vprint_info = print_info
         vprint_wait = print_wait
         vprint_done = print_done
-    if args.env is not None:
-        envs = {k: v for k, v in map(lambda s: s.split('=', 1), args.env)}
+    if env is not None:
+        envs = {k: v for k, v in map(lambda s: s.split('=', 1), env)}
     else:
         envs = {}
-    if args.files and args.code:
+    if files and code:
         print('You can run only either source files or command-line '
               'code snippet.', file=sys.stderr)
         sys.exit(1)
-    if not args.files and not args.code:
+    if not files and not code:
         print('You should provide the command-line code snippet using '
               '"-c" option if run without files.', file=sys.stderr)
         sys.exit(1)
-    if args.resources:
-        resources = {k: v for k, v in map(lambda s: s.split('=', 1), args.resources)}
+    if resources:
+        resources = {k: v for k, v in map(lambda s: s.split('=', 1), resources)}
     else:
         resources = {}  # use the defaults configured in the server
 
@@ -261,17 +315,17 @@ def run(args):
             if memslot:
                 resources['mem'] = memslot
 
-    if not (1 <= args.cluster_size < 4):
+    if not (1 <= cluster_size < 4):
         print('Invalid cluster size.', file=sys.stderr)
         sys.exit(1)
 
-    if args.env_range is None: args.env_range = []      # noqa
-    if args.build_range is None: args.build_range = []  # noqa
-    if args.exec_range is None: args.exec_range = []    # noqa
+    if env_range is None: env_range = []      # noqa
+    if build_range is None: build_range = []  # noqa
+    if exec_range is None: exec_range = []    # noqa
 
-    env_ranges = {v: r for v, r in args.env_range}
-    build_ranges = {v: r for v, r in args.build_range}
-    exec_ranges = {v: r for v, r in args.exec_range}
+    env_ranges = {v: r for v, r in env_range}
+    build_ranges = {v: r for v, r in build_range}
+    exec_ranges = {v: r for v, r in exec_range}
 
     env_var_maps = [dict(zip(env_ranges.keys(), values))
                     for values in itertools.product(*env_ranges.values())]
@@ -281,17 +335,17 @@ def run(args):
                      for values in itertools.product(*exec_ranges.values())]
     case_set = collections.OrderedDict()
     vmaps_product = itertools.product(env_var_maps, build_var_maps, exec_var_maps)
-    build_template = string.Template(args.build)
-    exec_template = string.Template(args.exec)
+    build_template = string.Template(build)
+    exec_template = string.Template(exec)
     env_templates = {k: string.Template(v) for k, v in envs.items()}
     for env_vmap, build_vmap, exec_vmap in vmaps_product:
         interpolated_envs = tuple((k, vt.substitute(env_vmap))
                                   for k, vt in env_templates.items())
-        if args.build:
+        if build:
             interpolated_build = build_template.substitute(build_vmap)
         else:
             interpolated_build = '*'
-        if args.exec:
+        if exec:
             interpolated_exec = exec_template.substitute(exec_vmap)
         else:
             interpolated_exec = '*'
@@ -299,14 +353,14 @@ def run(args):
 
     is_multi = (len(case_set) > 1)
     if is_multi:
-        if args.max_parallel <= 0:
+        if max_parallel <= 0:
             print('The number maximum parallel sessions must be '
                   'a positive integer.', file=sys.stderr)
             sys.exit(1)
-        if args.terminal:
+        if terminal:
             print('You cannot run multiple cases with terminal.', file=sys.stderr)
             sys.exit(1)
-        if not args.quiet:
+        if not quiet:
             vprint_info('Running multiple sessions for the following combinations:')
             for case in case_set.keys():
                 pretty_env = ' '.join('{}={}'.format(item[0], item[1])
@@ -318,13 +372,13 @@ def run(args):
                     clean_cmd, build_cmd, exec_cmd):
         try:
             kernel = session.Kernel.get_or_create(
-                args.lang,
+                lang,
                 client_token=session_id,
-                cluster_size=args.cluster_size,
-                mounts=args.mount,
+                cluster_size=cluster_size,
+                mounts=mount,
                 envs=envs,
                 resources=resources,
-                tag=args.tag)
+                tag=tag)
         except Exception as e:
             print_error(e)
             sys.exit(1)
@@ -334,9 +388,9 @@ def run(args):
             vprint_done('[{0}] Reusing session {0}...'.format(idx, kernel.kernel_id))
 
         try:
-            if args.files:
+            if files:
                 vprint_wait('[{0}] Uploading source files...'.format(idx))
-                ret = kernel.upload(args.files, basedir=args.basedir,
+                ret = kernel.upload(files, basedir=basedir,
                                     show_progress=True)
                 if ret.status // 100 != 2:
                     print_fail('[{0}] Uploading source files failed!'.format(idx))
@@ -349,26 +403,26 @@ def run(args):
                     'build': build_cmd,
                     'exec': exec_cmd,
                 }
-                if not args.terminal:
+                if not terminal:
                     exec_loop_sync(sys.stdout, sys.stderr, kernel, 'batch', '',
                                    opts=opts,
                                    vprint_done=vprint_done)
-            if args.terminal:
+            if terminal:
                 raise NotImplementedError('Terminal access is not supported in '
                                           'the legacy synchronous mode.')
-            if args.code:
-                exec_loop_sync(sys.stdout, sys.stderr, kernel, 'query', args.code,
+            if code:
+                exec_loop_sync(sys.stdout, sys.stderr, kernel, 'query', code,
                                vprint_done=vprint_done)
             vprint_done('[{0}] Execution finished.'.format(idx))
         except Exception as e:
             print_error(e)
             sys.exit(1)
         finally:
-            if args.rm:
+            if rm:
                 vprint_wait('[{0}] Cleaning up the session...'.format(idx))
                 ret = kernel.destroy()
                 vprint_done('[{0}] Cleaned up the session.'.format(idx))
-                if args.stats:
+                if stats:
                     stats = ret.get('stats', None) if ret else None
                     if stats:
                         print('[{0}] Statistics:\n{1}'
@@ -381,13 +435,13 @@ def run(args):
                    is_multi=False):
         try:
             kernel = await session.Kernel.get_or_create(
-                args.lang,
+                lang,
                 client_token=session_id,
-                cluster_size=args.cluster_size,
-                mounts=args.mount,
+                cluster_size=cluster_size,
+                mounts=mount,
                 envs=envs,
                 resources=resources,
-                tag=args.tag)
+                tag=tag)
         except BackendError as e:
             print_fail('[{0}] {1}'.format(idx, e))
             return
@@ -410,10 +464,10 @@ def run(args):
         try:
             def indexed_vprint_done(msg):
                 vprint_done('[{0}] '.format(idx) + msg)
-            if args.files:
+            if files:
                 if not is_multi:
                     vprint_wait('[{0}] Uploading source files...'.format(idx))
-                ret = await kernel.upload(args.files, basedir=args.basedir,
+                ret = await kernel.upload(files, basedir=basedir,
                                           show_progress=not is_multi)
                 if ret.status // 100 != 2:
                     print_fail('[{0}] Uploading source files failed!'.format(idx))
@@ -427,16 +481,16 @@ def run(args):
                     'build': build_cmd,
                     'exec': exec_cmd,
                 }
-                if not args.terminal:
+                if not terminal:
                     await exec_loop(stdout, stderr, kernel, 'batch', '',
                                     opts=opts,
                                     vprint_done=indexed_vprint_done,
                                     is_multi=is_multi)
-            if args.terminal:
+            if terminal:
                 await exec_terminal(kernel)
                 return
-            if args.code:
-                await exec_loop(stdout, stderr, kernel, 'query', args.code,
+            if code:
+                await exec_loop(stdout, stderr, kernel, 'query', code,
                                 vprint_done=indexed_vprint_done,
                                 is_multi=is_multi)
         except BackendError as e:
@@ -448,12 +502,12 @@ def run(args):
             raise RuntimeError(e)
         finally:
             try:
-                if args.rm:
+                if rm:
                     if not is_multi:
                         vprint_wait('[{0}] Cleaning up the session...'.format(idx))
                     ret = await kernel.destroy()
                     vprint_done('[{0}] Cleaned up the session.'.format(idx))
-                    if args.stats:
+                    if stats:
                         stats = ret.get('stats', None) if ret else None
                         if stats:
                             stats_str = _format_stats(stats)
@@ -472,10 +526,10 @@ def run(args):
                     stderr.close()
 
     def _run_cases_legacy():
-        if args.session_id is None:
+        if session_id is None:
             session_id_prefix = token_hex(5)
         else:
-            session_id_prefix = args.session_id
+            session_id_prefix = session_id
         vprint_info('Session token prefix: {0}'.format(session_id_prefix))
         vprint_info('In the legacy mode, all cases will run serially!')
         with Session() as session:
@@ -485,7 +539,7 @@ def run(args):
                 else:
                     session_id = session_id_prefix
                 envs = dict(case[0])
-                clean_cmd = args.clean if args.clean else '*'
+                clean_cmd = clean if clean else '*'
                 build_cmd = case[1]
                 exec_cmd = case[2]
                 _run_legacy(session, args, idx, session_id, envs,
@@ -493,10 +547,10 @@ def run(args):
 
     async def _run_cases():
         loop = current_loop()
-        if args.session_id is None:
+        if session_id is None:
             session_id_prefix = token_hex(5)
         else:
-            session_id_prefix = args.session_id
+            session_id_prefix = session_id
         vprint_info('Session token prefix: {0}'.format(session_id_prefix))
         if is_multi:
             print_info('Check out the stdout/stderr logs stored in '
@@ -510,7 +564,7 @@ def run(args):
                 else:
                     session_id = session_id_prefix
                 envs = dict(case[0])
-                clean_cmd = args.clean if args.clean else '*'
+                clean_cmd = clean if clean else '*'
                 build_cmd = case[1]
                 exec_cmd = case[2]
                 t = loop.create_task(
@@ -524,7 +578,7 @@ def run(args):
                     print_fail('There were failed cases!')
                 sys.exit(1)
 
-    if args.legacy:
+    if legacy:
         _run_cases_legacy()
     else:
         loop = asyncio.get_event_loop()
@@ -534,72 +588,24 @@ def run(args):
             loop.close()
 
 
-run.add_argument('lang',
-                 help='The runtime or programming language name')
-run.add_argument('files', nargs='*', type=Path,
-                 help='The code file(s). Can be added multiple times')
-run.add_argument('-t', '--session-id', '--client-token', metavar='SESSID',
-                 help='Specify a human-readable session ID or name. '
-                      'If not set, a random hex string is used.')
-run.add_argument('--cluster-size', metavar='NUMBER', type=int, default=1,
-                 help='The size of cluster in number of containers.')
-run.add_argument('-c', '--code', metavar='CODE',
-                 help='The code snippet as a single string')
-run.add_argument('--clean', metavar='CMD',
-                 help='Custom shell command for cleaning up the base directory')
-run.add_argument('--build', metavar='CMD',
-                 help='Custom shell command for building the given files')
-run.add_argument('--exec', metavar='CMD',
-                 help='Custom shell command for executing the given files')
-run.add_argument('--terminal', action='store_true', default=False,
-                 help='Connect to the terminal-type kernel.')
-run.add_argument('--basedir', metavar='PATH', type=Path, default=None,
-                 help='Base directory path of uploaded files.  '
-                      'All uploaded files must reside inside this directory.')
-run.add_argument('--rm', action='store_true', default=False,
-                 help='Terminate the session immediately after running '
-                      'the given code or files')
-run.add_argument('-e', '--env', metavar='KEY=VAL', type=str, action='append',
-                 help='Environment variable '
-                      '(may appear multiple times)')
-run.add_argument('--env-range', metavar='RANGE_EXPR', action='append',
-                 type=range_expr,
-                 help='Range expression for environment variable.')
-run.add_argument('--build-range', metavar='RANGE_EXPR', action='append',
-                 type=range_expr,
-                 help='Range expression for execution arguments.')
-run.add_argument('--exec-range', metavar='RANGE_EXPR', action='append',
-                 type=range_expr,
-                 help='Range expression for execution arguments.')
-run.add_argument('--max-parallel', metavar='NUM', type=int, default=2,
-                 help='The maximum number of parallel sessions.')
-run.add_argument('-m', '--mount', type=str, action='append',
-                 help='User-owned virtual folder names to mount')
-run.add_argument('-s', '--stats', action='store_true', default=False,
-                 help='Show resource usage statistics after termination '
-                      '(only works if "--rm" is given)')
-run.add_argument('--tag', type=str, default=None,
-                 help='User-defined tag string to annotate sessions.')
-run.add_argument('-r', '--resources', metavar='KEY=VAL', type=str, action='append',
-                 help='Set computation resources (e.g: -r cpu=2 -r mem=256 -r gpu=1)'
-                 '. 1 slot of cpu/gpu represents 1 core. The unit of mem(ory) '
-                 'is MiB.')
-run.add_argument('-q', '--quiet', action='store_true', default=False,
-                 help='Hide execution details but show only the kernel outputs.')
-run.add_argument('--legacy', action='store_true', default=False,
-                 help='Use the legacy synchronous polling mode to '
-                      'fetch console outputs.')
 
 
-@register_command(aliases=['rm', 'kill'])
-def terminate(args):
+# @click.command(aliases=['rm', 'kill'])
+@click.command()
+@click.argument('sess_id_or_alias', metavar='SESSID', nargs=-1)
+@click.option('-s', '--stats', is_flag=True,
+              help='Show resource usage statistics after termination')
+def terminate(sess_id_or_alias, stats):
     '''
-    Terminate the given session.
+    Terminate the given session. SESSID is sessino ID or its alias given when
+    creating the session.
+
+    SESSID: session ID or its alias given when creating the session.
     '''
     print_wait('Terminating the session(s)...')
     with Session() as session:
         has_failure = False
-        for sess in args.sess_id_or_alias:
+        for sess in sess_id_or_alias:
             try:
                 kernel = session.Kernel(sess)
                 ret = kernel.destroy()
@@ -610,7 +616,7 @@ def terminate(args):
                 sys.exit(1)
         else:
             print_done('Done.')
-            if args.stats:
+            if stats:
                 stats = ret.get('stats', None) if ret else None
                 if stats:
                     print(_format_stats(stats))
@@ -618,24 +624,14 @@ def terminate(args):
                     print('Statistics is not available.')
 
 
-terminate.add_argument('sess_id_or_alias', metavar='NAME', nargs='+',
-                       help='The session ID or its alias '
-                            'given when creating the session.')
-terminate.add_argument('-s', '--stats', action='store_true', default=False,
-                       help='Show resource usage statistics after termination')
-
-
-@register_command
-def info(args):
+@click.command()
+@click.argument('sess_id_or_alias', metavar='NAME')
+@click.pass_context
+def info(ctx, sess_id_or_alias):
     '''
     Show detailed information for a running compute session.
     This is an alias of the "admin session <sess_id>" command.
+
+    SESSID: session ID or its alias given when creating the session.
     '''
-    inner_args = Namespace()
-    inner_args.sess_id_or_alias = args.sess_id_or_alias
-    session(inner_args)
-
-
-info.add_argument('sess_id_or_alias', metavar='NAME',
-                  help='The session ID or its alias '
-                       'given when creating the session.')
+    ctx.forward(session)

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -6,13 +6,13 @@ import sys
 import click
 from tabulate import tabulate
 
-from . import main
+from . import AliasGroup, main
 from ..config import get_config
 from .pretty import print_wait, print_done, print_error, print_fail
 from ..session import Session
 
 
-@main.group()
+@main.group(cls=AliasGroup)
 def vfolder():
     '''Provides virtual folder operations.'''
 
@@ -169,8 +169,7 @@ def mkdir(name, path):
             sys.exit(1)
 
 
-# @vfolder.command(aliases=['delete-file'])
-@vfolder.command()
+@vfolder.command(aliases=['delete-file'])
 @click.argument('name', type=str)
 @click.argument('filenames', nargs=-1)
 @click.option('-r', '--recursive', is_flag=True,

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -6,12 +6,13 @@ import sys
 import click
 from tabulate import tabulate
 
+from . import main
 from ..config import get_config
 from .pretty import print_wait, print_done, print_error, print_fail
 from ..session import Session
 
 
-@click.group()
+@main.group()
 def vfolder():
     '''Provides virtual folder operations.'''
 

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -14,7 +14,6 @@ from ..session import Session
 @click.group()
 def vfolder():
     '''Provides virtual folder operations.'''
-    print('Run with -h/--help for usage.')
 
 
 @vfolder.command()
@@ -46,6 +45,7 @@ def list():
 def create(name, host):
     '''Create a new virtual folder.
 
+    \b
     NAME: Name of a virtual folder.
     HOST: Name of a virtual folder host in which the virtual folder will be created.
     '''
@@ -101,6 +101,7 @@ def upload(name, filenames):
     Upload a file to the virtual folder from the current working directory.
     The files with the same names will be overwirtten.
 
+    \b
     NAME: Name of a virtual folder.
     FILENAMES: Paths of the files to be uploaded.
     '''
@@ -121,6 +122,7 @@ def download(name, filenames):
     Download a file from the virtual folder to the current working directory.
     The files with the same names will be overwirtten.
 
+    \b
     NAME: Name of a virtual folder.
     FILENAMES: Paths of the files to be uploaded.
     '''
@@ -152,9 +154,10 @@ def cp(filenames):
 def mkdir(name, path):
     '''Create an empty directory in the virtual folder.
 
+    \b
     NAME: Name of a virtual folder.
-    PATH: The name or path of directory.  Parent directories are created
-          automatically if they do not exist.
+    PATH: The name or path of directory. Parent directories are created automatically
+          if they do not exist.
     '''
     with Session() as session:
         try:
@@ -179,6 +182,7 @@ def rm(name, filenames, recursive):
 
     This operation is irreversible!
 
+    \b
     NAME: Name of a virtual folder.
     FILENAMES: Paths of the files to delete.
     '''
@@ -201,6 +205,7 @@ def ls(name, path):
     """
     List files in a path of a virtual folder.
 
+    \b
     NAME: Name of a virtual folder.
     PATH: Path inside vfolder.
     """
@@ -233,6 +238,7 @@ def ls(name, path):
 def invite(name, emails, perm):
     """Invite other users to access the virtual folder.
 
+    \b
     NAME: Name of a virtual folder.
     EMAIL: Emails to invite.
     """
@@ -254,7 +260,7 @@ def invite(name, emails, perm):
 
 
 @vfolder.command()
-def invitations(args):
+def invitations():
     """List and manage received invitations.
     """
     with Session() as session:

--- a/src/ai/backend/client/request.py
+++ b/src/ai/backend/client/request.py
@@ -9,7 +9,6 @@ import aiohttp.web
 from dateutil.tz import tzutc
 from multidict import CIMultiDict
 import json as modjson
-from yarl import URL
 
 from .auth import generate_signature
 from .exceptions import BackendClientError, BackendAPIError


### PR DESCRIPTION
Related to issue #46.

* Click package is adopted to improve development of cli commands.
* Custom parsers and `register_command` was removed.
* Added custom `Group` class to support command alias (which is not supported natively in Click).
* `lcc` and `lpython` commands are still working, but the entry point is separated from the main entry point.