### PR TITLE
client implementation for remote ipython kernel support

### DIFF
--- a/src/ai/backend/client/cli/app.py
+++ b/src/ai/backend/client/cli/app.py
@@ -186,33 +186,7 @@ def app(session_id, app, bind, port):
     APP: The name of service provided by the given session.
     """
     if app == 'ipython':
-        # STDIN_FILENO = 0
-        # STDOUT_FILENO = 1
         print_info("ipython kernel started. type ^\ to exit")
-        # loop = current_loop()
-        # async def set_stream():
-        #     global stream
-        #     async with AsyncSession() as session:
-        #         async with session.Kernel(session_id).stream_pty() as _stream:
-        #             await _stream.send_stdin('v')
-        #             stream = _stream
-        # loop.run_until_complete(set_stream())
-
-        # def signal_handler(signame):
-        #     if signame == 'SIGTERM':
-        #         sys.exit(0)
-        #     else:
-        #         asyncio.run_coroutine_threadsafe(stream.send_signal(signame), loop)
-        # for signame in ['SIGINT', 'SIGTSTP', 'SIGTERM']:
-        #     loop.add_signal_handler(
-        #         getattr(signal, signame),
-        #         functools.partial(signal_handler, signame))
-        
-        # def listen_stdin():
-        #     data = os.read(STDIN_FILENO, 1024)
-        #     asyncio.run_coroutine_threadsafe(stream.send_stdin(data), loop)
-        # loop.add_reader(STDIN_FILENO, listen_stdin)
-        # loop.run_forever()
         IpythonClient(session_id).start()
     else:
         api_session = None

--- a/src/ai/backend/client/kernel.py
+++ b/src/ai/backend/client/kernel.py
@@ -447,13 +447,26 @@ class StreamPty(WebSocketResponse):
     __slots__ = ('ws', )
 
     async def resize(self, rows, cols):
-        await self.ws.send_str(json.dumps({
+        await self.send_json({
             'type': 'resize',
             'rows': rows,
             'cols': cols,
-        }))
+        })
 
     async def restart(self):
-        await self.ws.send_str(json.dumps({
+        await self.send_json({
             'type': 'restart',
-        }))
+        })
+
+    async def send_stdin(self, stdin_chars):
+        await self.send_json({
+            'type': 'stdin',
+            'chars': stdin_chars,
+        })
+
+    async def send_signal(self, signame):
+        await self.send_json({
+            'type': 'signal',
+            'signame': signame,
+        })
+

--- a/src/ai/backend/client/kernel.py
+++ b/src/ai/backend/client/kernel.py
@@ -447,16 +447,16 @@ class StreamPty(WebSocketResponse):
     __slots__ = ('ws', )
 
     async def resize(self, rows, cols):
-        await self.send_json({
+        await self.ws.send_str(json.dumps({
             'type': 'resize',
             'rows': rows,
             'cols': cols,
-        })
+        }))
 
     async def restart(self):
-        await self.send_json({
+        await self.ws.send_str(json.dumps({
             'type': 'restart',
-        })
+        }))
 
     async def send_stdin(self, stdin_chars):
         await self.send_json({

--- a/src/ai/backend/client/request.py
+++ b/src/ai/backend/client/request.py
@@ -487,7 +487,7 @@ class WebSocketContextManager:
                  response_cls: WebSocketResponse = WebSocketResponse):
         self.session = session
         self.ws_ctx = ws_ctx
-        self.response_cls = WebSocketResponse
+        self.response_cls = response_cls
         self.on_enter = on_enter
 
     async def __aenter__(self):


### PR DESCRIPTION
client cli ```backend.ai app SESS_ID ipython``` command

1. request resizing to remote kernel pty by sending client's terminal size
    json ```{'type' : 'resize', 'rows' : ROWS, 'cols' : COLS}```

2. listen to client stdin -> send to websocket connected to manager
    json ```{'type' : 'stdin', 'chars' : CLIENT_STDIN_CHARS}```

3. listen to client signal -> send to websocket connected to manager
    (instead of sending signal to running client process)
    json ```{'type' : 'signal', 'signame' : NAME_OF_SIGNAL}```

4. listen to websocket connected to manager -> write to client stdin