### PR TITLE
Agent watcher support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ local-samples
 env-*.sh
 env_*.sh
 .ipynb_checkpoints
+
+.vscode/

--- a/src/ai/backend/client/agent.py
+++ b/src/ai/backend/client/agent.py
@@ -129,11 +129,11 @@ class AgentWatcher:
 
     @api_function
     @classmethod
-    async def soft_reset(cls, agent_id: str) -> dict:
+    async def agent_start(cls, agent_id: str) -> dict:
         '''
-        Soft reset an agent.
+        Start agent.
         '''
-        rqst = Request(cls.session, 'POST', '/resource/watcher/soft-reset')
+        rqst = Request(cls.session, 'POST', '/resource/watcher/agent/start')
         rqst.set_json({'agent_id': agent_id})
         async with rqst.fetch() as resp:
             data = await resp.json()
@@ -144,11 +144,11 @@ class AgentWatcher:
 
     @api_function
     @classmethod
-    async def hard_reset(cls, agent_id: str) -> dict:
+    async def stop(cls, agent_id: str) -> dict:
         '''
-        Hard reset an agent.
+        Stop agent.
         '''
-        rqst = Request(cls.session, 'POST', '/resource/watcher/hard-reset')
+        rqst = Request(cls.session, 'POST', '/resource/watcher/agent/stop')
         rqst.set_json({'agent_id': agent_id})
         async with rqst.fetch() as resp:
             data = await resp.json()
@@ -159,26 +159,11 @@ class AgentWatcher:
 
     @api_function
     @classmethod
-    async def shutdown(cls, agent_id: str) -> dict:
+    async def restart(cls, agent_id: str) -> dict:
         '''
-        Shutdown an agent.
+        Restart agent.
         '''
-        rqst = Request(cls.session, 'POST', '/resource/watcher/shutdown')
-        rqst.set_json({'agent_id': agent_id})
-        async with rqst.fetch() as resp:
-            data = await resp.json()
-            if 'message' in data:
-                return data['message']
-            else:
-                return data
-
-    @api_function
-    @classmethod
-    async def start(cls, agent_id: str) -> dict:
-        '''
-        Start an agent.
-        '''
-        rqst = Request(cls.session, 'POST', '/resource/watcher/start')
+        rqst = Request(cls.session, 'POST', '/resource/watcher/agent/restart')
         rqst.set_json({'agent_id': agent_id})
         async with rqst.fetch() as resp:
             data = await resp.json()

--- a/src/ai/backend/client/agent.py
+++ b/src/ai/backend/client/agent.py
@@ -6,6 +6,7 @@ from .request import Request
 
 __all__ = (
     'Agent',
+    'AgentWatcher',
 )
 
 
@@ -95,3 +96,93 @@ class Agent:
         async with rqst.fetch() as resp:
             data = await resp.json()
             return data['agent']
+
+
+class AgentWatcher:
+    '''
+    Provides a shortcut of :func:`Admin.query()
+    <ai.backend.client.admin.Admin.query>` that manipulate agent status.
+
+    .. note::
+
+      All methods in this function class require you to
+      have the *superadmin* privilege.
+    '''
+
+    session = None
+    '''The client session instance that this function class is bound to.'''
+
+    @api_function
+    @classmethod
+    async def get_status(cls, agent_id: str) -> dict:
+        '''
+        Get agent and watcher status.
+        '''
+        rqst = Request(cls.session, 'GET', '/resource/watcher')
+        rqst.set_json({'agent_id': agent_id})
+        async with rqst.fetch() as resp:
+            data = await resp.json()
+            if 'message' in data:
+                return data['message']
+            else:
+                return data
+
+    @api_function
+    @classmethod
+    async def soft_reset(cls, agent_id: str) -> dict:
+        '''
+        Soft reset an agent.
+        '''
+        rqst = Request(cls.session, 'POST', '/resource/watcher/soft-reset')
+        rqst.set_json({'agent_id': agent_id})
+        async with rqst.fetch() as resp:
+            data = await resp.json()
+            if 'message' in data:
+                return data['message']
+            else:
+                return data
+
+    @api_function
+    @classmethod
+    async def hard_reset(cls, agent_id: str) -> dict:
+        '''
+        Hard reset an agent.
+        '''
+        rqst = Request(cls.session, 'POST', '/resource/watcher/hard-reset')
+        rqst.set_json({'agent_id': agent_id})
+        async with rqst.fetch() as resp:
+            data = await resp.json()
+            if 'message' in data:
+                return data['message']
+            else:
+                return data
+
+    @api_function
+    @classmethod
+    async def shutdown(cls, agent_id: str) -> dict:
+        '''
+        Shutdown an agent.
+        '''
+        rqst = Request(cls.session, 'POST', '/resource/watcher/shutdown')
+        rqst.set_json({'agent_id': agent_id})
+        async with rqst.fetch() as resp:
+            data = await resp.json()
+            if 'message' in data:
+                return data['message']
+            else:
+                return data
+
+    @api_function
+    @classmethod
+    async def start(cls, agent_id: str) -> dict:
+        '''
+        Start an agent.
+        '''
+        rqst = Request(cls.session, 'POST', '/resource/watcher/start')
+        rqst.set_json({'agent_id': agent_id})
+        async with rqst.fetch() as resp:
+            data = await resp.json()
+            if 'message' in data:
+                return data['message']
+            else:
+                return data

--- a/src/ai/backend/client/agent.py
+++ b/src/ai/backend/client/agent.py
@@ -144,7 +144,7 @@ class AgentWatcher:
 
     @api_function
     @classmethod
-    async def stop(cls, agent_id: str) -> dict:
+    async def agent_stop(cls, agent_id: str) -> dict:
         '''
         Stop agent.
         '''
@@ -159,7 +159,7 @@ class AgentWatcher:
 
     @api_function
     @classmethod
-    async def restart(cls, agent_id: str) -> dict:
+    async def agent_restart(cls, agent_id: str) -> dict:
         '''
         Restart agent.
         '''

--- a/src/ai/backend/client/cli/admin/agents.py
+++ b/src/ai/backend/client/cli/admin/agents.py
@@ -127,3 +127,106 @@ def agents(status, all):
                             headers=(item[0] for item in fields)))
             if total_count > paginating_interval:
                 print("More agents can be displayed by using --all option.")
+
+
+@admin.group()
+def watcher():
+    '''Provides agent watcher operations.
+
+    Watcher operations are available only for Linux distributions.
+    '''
+
+
+@watcher.command()
+@click.argument('agent', type=str)
+def status(agent):
+    '''
+    Get agent and watcher status.
+    (superadmin privilege required)
+
+    \b
+    AGENT: Agent id.
+    '''
+    with Session() as session:
+        try:
+            status = session.AgentWatcher.get_status(agent)
+            print(status)
+        except Exception as e:
+            print_error(e)
+            sys.exit(1)
+
+
+@watcher.command()
+@click.argument('agent', type=str)
+def soft_reset(agent):
+    '''
+    Soft reset an agent (reload agent service).
+    (superadmin privilege required)
+
+    \b
+    AGENT: Agent id.
+    '''
+    with Session() as session:
+        try:
+            status = session.AgentWatcher.soft_reset(agent)
+            print(status)
+        except Exception as e:
+            print_error(e)
+            sys.exit(1)
+
+
+@watcher.command()
+@click.argument('agent', type=str)
+def hard_reset(agent):
+    '''
+    Hard reset an agent (restart agent/docker services).
+    (superadmin privilege required)
+
+    \b
+    AGENT: Agent id.
+    '''
+    with Session() as session:
+        try:
+            status = session.AgentWatcher.hard_reset(agent)
+            print(status)
+        except Exception as e:
+            print_error(e)
+            sys.exit(1)
+
+
+@watcher.command()
+@click.argument('agent', type=str)
+def shutdown(agent):
+    '''
+    Stop agent service.
+    (superadmin privilege required)
+
+    \b
+    AGENT: Agent id.
+    '''
+    with Session() as session:
+        try:
+            status = session.AgentWatcher.shutdown(agent)
+            print(status)
+        except Exception as e:
+            print_error(e)
+            sys.exit(1)
+
+
+@watcher.command()
+@click.argument('agent', type=str)
+def start(agent):
+    '''
+    Start agent service.
+    (superadmin privilege required)
+
+    \b
+    AGENT: Agent id.
+    '''
+    with Session() as session:
+        try:
+            status = session.AgentWatcher.start(agent)
+            print(status)
+        except Exception as e:
+            print_error(e)
+            sys.exit(1)

--- a/src/ai/backend/client/cli/admin/agents.py
+++ b/src/ai/backend/client/cli/admin/agents.py
@@ -158,64 +158,7 @@ def status(agent):
 
 @watcher.command()
 @click.argument('agent', type=str)
-def soft_reset(agent):
-    '''
-    Soft reset an agent (reload agent service).
-    (superadmin privilege required)
-
-    \b
-    AGENT: Agent id.
-    '''
-    with Session() as session:
-        try:
-            status = session.AgentWatcher.soft_reset(agent)
-            print(status)
-        except Exception as e:
-            print_error(e)
-            sys.exit(1)
-
-
-@watcher.command()
-@click.argument('agent', type=str)
-def hard_reset(agent):
-    '''
-    Hard reset an agent (restart agent/docker services).
-    (superadmin privilege required)
-
-    \b
-    AGENT: Agent id.
-    '''
-    with Session() as session:
-        try:
-            status = session.AgentWatcher.hard_reset(agent)
-            print(status)
-        except Exception as e:
-            print_error(e)
-            sys.exit(1)
-
-
-@watcher.command()
-@click.argument('agent', type=str)
-def shutdown(agent):
-    '''
-    Stop agent service.
-    (superadmin privilege required)
-
-    \b
-    AGENT: Agent id.
-    '''
-    with Session() as session:
-        try:
-            status = session.AgentWatcher.shutdown(agent)
-            print(status)
-        except Exception as e:
-            print_error(e)
-            sys.exit(1)
-
-
-@watcher.command()
-@click.argument('agent', type=str)
-def start(agent):
+def agent_start(agent):
     '''
     Start agent service.
     (superadmin privilege required)
@@ -225,7 +168,45 @@ def start(agent):
     '''
     with Session() as session:
         try:
-            status = session.AgentWatcher.start(agent)
+            status = session.AgentWatcher.agent_start(agent)
+            print(status)
+        except Exception as e:
+            print_error(e)
+            sys.exit(1)
+
+
+@watcher.command()
+@click.argument('agent', type=str)
+def agent_stop(agent):
+    '''
+    Stop agent service.
+    (superadmin privilege required)
+
+    \b
+    AGENT: Agent id.
+    '''
+    with Session() as session:
+        try:
+            status = session.AgentWatcher.agent_stop(agent)
+            print(status)
+        except Exception as e:
+            print_error(e)
+            sys.exit(1)
+
+
+@watcher.command()
+@click.argument('agent', type=str)
+def agent_restart(agent):
+    '''
+    Restart agent service.
+    (superadmin privilege required)
+
+    \b
+    AGENT: Agent id.
+    '''
+    with Session() as session:
+        try:
+            status = session.AgentWatcher.agent_restart(agent)
             print(status)
         except Exception as e:
             print_error(e)

--- a/src/ai/backend/client/session.py
+++ b/src/ai/backend/client/session.py
@@ -72,7 +72,7 @@ class BaseSession(metaclass=abc.ABCMeta):
 
     __slots__ = (
         '_config', '_closed', 'aiohttp_session',
-        'Admin', 'Agent', 'Domain', 'Group', 'ScalingGroup',
+        'Admin', 'Agent', 'AgentWatcher', 'Domain', 'Group', 'ScalingGroup',
         'Image', 'Kernel', 'KeyPair', 'Manager', 'Resource',
         'KeypairResourcePolicy', 'User', 'VFolder',
     )
@@ -131,7 +131,7 @@ class Session(BaseSession):
 
         from .base import BaseFunction
         from .admin import Admin
-        from .agent import Agent
+        from .agent import Agent, AgentWatcher
         from .domain import Domain
         from .group import Group
         from .image import Image
@@ -159,6 +159,15 @@ class Session(BaseSession):
         })
         '''
         The :class:`~ai.backend.client.agent.Agent` function proxy
+        bound to this session.
+        '''
+
+        self.AgentWatcher = type('AgentWatcher', (BaseFunction, ), {
+            **AgentWatcher.__dict__,
+            'session': self,
+        })
+        '''
+        The :class:`~ai.backend.client.agent.AgentWatcher` function proxy
         bound to this session.
         '''
 
@@ -313,7 +322,7 @@ class AsyncSession(BaseSession):
 
         from .base import BaseFunction
         from .admin import Admin
-        from .agent import Agent
+        from .agent import Agent, AgentWatcher
         from .group import Group
         from .image import Image
         from .kernel import Kernel
@@ -340,6 +349,15 @@ class AsyncSession(BaseSession):
         })
         '''
         The :class:`~ai.backend.client.agent.Agent` function proxy
+        bound to this session.
+        '''
+
+        self.AgentWatcher = type('AgentWatcher', (BaseFunction, ), {
+            **AgentWatcher.__dict__,
+            'session': self,
+        })
+        '''
+        The :class:`~ai.backend.client.agent.AgentWatcher` function proxy
         bound to this session.
         '''
 


### PR DESCRIPTION
Added agent watcher commands.

-  Get agent/watcher status: `backendai admin watcher status`
-  Start agent: `backendai admin watcher start <agent-id>`
-  Stop agent: `backendai admin watcher stop <agent-id>`
-  Restart agent: `backendai admin watcher restart <agent-id>`