### PR TITLE
Add resource_opts option in creating a session

### DIFF
--- a/src/ai/backend/client/cli/run.py
+++ b/src/ai/backend/client/cli/run.py
@@ -323,6 +323,9 @@ def _prepare_mount_arg(mount):
                    '(e.g: -r cpu=2 -r mem=256 -r cuda.device=1)')
 @click.option('--cluster-size', metavar='NUMBER', type=int, default=1,
               help='The size of cluster in number of containers.')
+@click.option('--extra-resources', metavar='KEY=VAL', type=str, multiple=True,
+              help='Extra resource specs for creating compute session. '
+                   '(e.g: shm-size=64m)')
 # resource grouping
 @click.option('-d', '--domain', metavar='DOMAIN_NAME', default=None,
               help='Domain name where the session will be spawned. '
@@ -337,6 +340,7 @@ def run(image, files, session_id,                          # base args
         rm, stats, tag, quiet,                             # extra options
         env_range, build_range, exec_range, max_parallel,  # experiment support
         mount, scaling_group, resources, cluster_size,     # resource spec
+        extra_resources,
         domain, group):                                    # resource grouping
     '''
     Run the given code snippet or files in a session.
@@ -365,6 +369,7 @@ def run(image, files, session_id,                          # base args
 
     envs = _prepare_env_arg(env)
     resources = _prepare_resource_arg(resources)
+    extra_resources = _prepare_resource_arg(extra_resources)
     mount = _prepare_mount_arg(mount)
 
     if not (1 <= cluster_size < 4):
@@ -499,6 +504,7 @@ def run(image, files, session_id,                          # base args
                 mounts=mount,
                 envs=envs,
                 resources=resources,
+                extra_resources=extra_resources,
                 domain_name=domain,
                 group_name=group,
                 scaling_group=scaling_group,
@@ -683,6 +689,9 @@ def run(image, files, session_id,                          # base args
                    'The unit of mem(ory) is MiB.')
 @click.option('--cluster-size', metavar='NUMBER', type=int, default=1,
               help='The size of cluster in number of containers.')
+@click.option('--extra-resources', metavar='KEY=VAL', type=str, multiple=True,
+              help='Extra resource specs for creating compute session '
+                   '(e.g: shm-size=64m)')
 # resource grouping
 @click.option('-d', '--domain', metavar='DOMAIN_NAME', default=None,
               help='Domain name where the session will be spawned. '
@@ -694,6 +703,7 @@ def start(image, session_id, owner,                        # base args
           env,                                            # execution environment
           tag,                                            # extra options
           mount, scaling_group, resources, cluster_size,  # resource spec
+          extra_resources,
           domain, group):                                 # resource grouping
     '''
     Prepare and start a single compute session without executing codes.
@@ -714,6 +724,7 @@ def start(image, session_id, owner,                        # base args
     ######
     envs = _prepare_env_arg(env)
     resources = _prepare_resource_arg(resources)
+    extra_resources = _prepare_resource_arg(extra_resources)
     mount = _prepare_mount_arg(mount)
     with Session() as session:
         try:
@@ -724,6 +735,7 @@ def start(image, session_id, owner,                        # base args
                 mounts=mount,
                 envs=envs,
                 resources=resources,
+                extra_resources=extra_resources,
                 owner_access_key=owner,
                 domain_name=domain,
                 group_name=group,

--- a/src/ai/backend/client/cli/run.py
+++ b/src/ai/backend/client/cli/run.py
@@ -323,8 +323,8 @@ def _prepare_mount_arg(mount):
                    '(e.g: -r cpu=2 -r mem=256 -r cuda.device=1)')
 @click.option('--cluster-size', metavar='NUMBER', type=int, default=1,
               help='The size of cluster in number of containers.')
-@click.option('--extra-resources', metavar='KEY=VAL', type=str, multiple=True,
-              help='Extra resource specs for creating compute session. '
+@click.option('--resource-opts', metavar='KEY=VAL', type=str, multiple=True,
+              help='Resource options for creating compute session. '
                    '(e.g: shm-size=64m)')
 # resource grouping
 @click.option('-d', '--domain', metavar='DOMAIN_NAME', default=None,
@@ -340,7 +340,7 @@ def run(image, files, session_id,                          # base args
         rm, stats, tag, quiet,                             # extra options
         env_range, build_range, exec_range, max_parallel,  # experiment support
         mount, scaling_group, resources, cluster_size,     # resource spec
-        extra_resources,
+        resource_opts,
         domain, group):                                    # resource grouping
     '''
     Run the given code snippet or files in a session.
@@ -369,7 +369,7 @@ def run(image, files, session_id,                          # base args
 
     envs = _prepare_env_arg(env)
     resources = _prepare_resource_arg(resources)
-    extra_resources = _prepare_resource_arg(extra_resources)
+    resource_opts = _prepare_resource_arg(resource_opts)
     mount = _prepare_mount_arg(mount)
 
     if not (1 <= cluster_size < 4):
@@ -504,7 +504,7 @@ def run(image, files, session_id,                          # base args
                 mounts=mount,
                 envs=envs,
                 resources=resources,
-                extra_resources=extra_resources,
+                resource_opts=resources_opts,
                 domain_name=domain,
                 group_name=group,
                 scaling_group=scaling_group,
@@ -689,8 +689,8 @@ def run(image, files, session_id,                          # base args
                    'The unit of mem(ory) is MiB.')
 @click.option('--cluster-size', metavar='NUMBER', type=int, default=1,
               help='The size of cluster in number of containers.')
-@click.option('--extra-resources', metavar='KEY=VAL', type=str, multiple=True,
-              help='Extra resource specs for creating compute session '
+@click.option('--resource-opts', metavar='KEY=VAL', type=str, multiple=True,
+              help='Resource options for creating compute session '
                    '(e.g: shm-size=64m)')
 # resource grouping
 @click.option('-d', '--domain', metavar='DOMAIN_NAME', default=None,
@@ -703,7 +703,7 @@ def start(image, session_id, owner,                        # base args
           env,                                            # execution environment
           tag,                                            # extra options
           mount, scaling_group, resources, cluster_size,  # resource spec
-          extra_resources,
+          resource_opts,
           domain, group):                                 # resource grouping
     '''
     Prepare and start a single compute session without executing codes.
@@ -724,7 +724,7 @@ def start(image, session_id, owner,                        # base args
     ######
     envs = _prepare_env_arg(env)
     resources = _prepare_resource_arg(resources)
-    extra_resources = _prepare_resource_arg(extra_resources)
+    resource_opts = _prepare_resource_arg(resource_opts)
     mount = _prepare_mount_arg(mount)
     with Session() as session:
         try:
@@ -735,7 +735,7 @@ def start(image, session_id, owner,                        # base args
                 mounts=mount,
                 envs=envs,
                 resources=resources,
-                extra_resources=extra_resources,
+                resource_opts=resource_opts,
                 owner_access_key=owner,
                 domain_name=domain,
                 group_name=group,

--- a/src/ai/backend/client/kernel.py
+++ b/src/ai/backend/client/kernel.py
@@ -53,7 +53,7 @@ class Kernel:
                             mounts: Iterable[str] = None,
                             envs: Mapping[str, str] = None,
                             resources: Mapping[str, int] = None,
-                            extra_resources: Mapping[str, int] = None,
+                            resource_opts: Mapping[str, int] = None,
                             cluster_size: int = 1,
                             domain_name: str = None,
                             group_name: str = None,
@@ -95,8 +95,8 @@ class Kernel:
             mounts = []
         if resources is None:
             resources = {}
-        if extra_resources is None:
-            extra_resources = {}
+        if resource_opts is None:
+            resource_opts = {}
         if domain_name is None:
             # Even if config.domain is None, it can be guessed in the manager by user information.
             domain_name = cls.session.config.domain
@@ -116,7 +116,7 @@ class Kernel:
                 'environ': envs,
                 'clusterSize': cluster_size,
                 'resources': resources,
-                'extra_resources': extra_resources,
+                'resource_opts': resource_opts,
                 'scalingGroup': scaling_group,
             },
         })

--- a/src/ai/backend/client/kernel.py
+++ b/src/ai/backend/client/kernel.py
@@ -53,6 +53,7 @@ class Kernel:
                             mounts: Iterable[str] = None,
                             envs: Mapping[str, str] = None,
                             resources: Mapping[str, int] = None,
+                            extra_resources: Mapping[str, int] = None,
                             cluster_size: int = 1,
                             domain_name: str = None,
                             group_name: str = None,
@@ -94,6 +95,8 @@ class Kernel:
             mounts = []
         if resources is None:
             resources = {}
+        if extra_resources is None:
+            extra_resources = {}
         if domain_name is None:
             # Even if config.domain is None, it can be guessed in the manager by user information.
             domain_name = cls.session.config.domain
@@ -113,6 +116,7 @@ class Kernel:
                 'environ': envs,
                 'clusterSize': cluster_size,
                 'resources': resources,
+                'extra_resources': extra_resources,
                 'scalingGroup': scaling_group,
             },
         })


### PR DESCRIPTION
In `resource_opts` option, shared memory size can be specified like `--resource-opts shm-size 1g`.