### PR TITLE
Support batch tasks

### DIFF
--- a/src/ai/backend/client/cli/admin/sessions.py
+++ b/src/ai/backend/client/cli/admin/sessions.py
@@ -24,6 +24,7 @@ from ..pretty import print_error
               help='Get sessions for a specific access key '
                    '(only works if you are a super-admin)')
 @click.option('--id-only', is_flag=True, help='Display session ids only.')
+@click.option('--show-tid', is_flag=True, help='Display task/kernel IDs.')
 @click.option('--dead', is_flag=True,
               help='Filter only dead sessions. Ignores --status option.')
 @click.option('--running', is_flag=True,
@@ -31,7 +32,7 @@ from ..pretty import print_error
 @click.option('-a', '--all', is_flag=True,
               help='Display all sessions matching the condition using pagination.')
 @click.option('--detail', is_flag=True, help='Show more details using more columns.')
-def sessions(status, access_key, id_only, dead, running, all, detail):
+def sessions(status, access_key, id_only, show_tid, dead, running, all, detail):
     '''
     List and manage compute sessions.
     '''
@@ -48,10 +49,16 @@ def sessions(status, access_key, id_only, dead, running, all, detail):
     if not id_only:
         fields.extend([
             ('Image', 'image'),
+            ('Type', 'sess_type'),
             ('Status', 'status'),
             ('Status Info', 'status_info'),
             ('Last updated', 'status_changed'),
+            ('Result', 'result'),
         ])
+        if show_tid:
+            fields.insert(
+                2,
+                ('Task/Kernel ID', 'id'))
         if detail:
             fields.extend([
                 ('Tag', 'tag'),

--- a/src/ai/backend/client/cli/ps.py
+++ b/src/ai/backend/client/cli/ps.py
@@ -15,6 +15,7 @@ from .admin.sessions import sessions
               ]),
               help='Filter by the given status')
 @click.option('--id-only', is_flag=True, help='Display session ids only.')
+@click.option('--show-tid', is_flag=True, help='Display task/kernel IDs.')
 @click.option('--dead', is_flag=True,
               help='Filter only dead sessions. Ignores --status option.')
 @click.option('--running', is_flag=True,
@@ -23,7 +24,7 @@ from .admin.sessions import sessions
               help='Display all sessions matching the condition using pagination.')
 @click.option('--detail', is_flag=True, help='Show more details using more columns.')
 @click.pass_context
-def ps(ctx, status, id_only, dead, running, all, detail):
+def ps(ctx, status, id_only, show_tid, dead, running, all, detail):
     '''
     Lists the current running compute sessions for the current keypair.
     This is an alias of the "admin sessions --status=RUNNING" command.

--- a/src/ai/backend/client/cli/run.py
+++ b/src/ai/backend/client/cli/run.py
@@ -276,7 +276,9 @@ def _prepare_mount_arg(mount):
               help='Specify a human-readable session ID or name. '
                    'If not set, a random hex string is used.')
 # job scheduling options
-@click.option('--type', metavar='SESSTYPE', default='interactive',
+@click.option('--type', metavar='SESSTYPE',
+              type=click.Choice(['batch', 'interactive']),
+              default='interactive',
               help='Either batch or interactive')
 @click.option('--enqueue-only', is_flag=True,
               help='Enqueue the session and return immediately without waiting for its startup.')
@@ -724,8 +726,12 @@ def run(image, files, session_id,                          # base args
 @click.option('-o', '--owner', '--owner-access-key', metavar='ACCESS_KEY',
               help='Set the owner of the target session explicitly.')
 # job scheduling options
-@click.option('--type', metavar='SESSTYPE', default='interactive',
+@click.option('--type', metavar='SESSTYPE',
+              type=click.Choice(['batch', 'interactive']),
+              default='interactive',
               help='Either batch or interactive')
+@click.option('-c', '--startup-command', metavar='COMMAND',
+              default='Set the command to execute for batch-type sessions.')
 @click.option('--enqueue-only', is_flag=True,
               help='Enqueue the session and return immediately without waiting for its startup.')
 @click.option('--max-wait', metavar='SECONDS', type=int, default=0,
@@ -761,8 +767,8 @@ def run(image, files, session_id,                          # base args
 @click.option('-g', '--group', metavar='GROUP_NAME', default=None,
               help='Group name where the session is spawned. '
                    'User should be a member of the group to execute the code.')
-def start(image, session_id, owner,                       # base args
-          type, enqueue_only, max_wait, no_reuse,         # job scheduling options
+def start(image, session_id, owner,                                 # base args
+          type, startup_command, enqueue_only, max_wait, no_reuse,  # job scheduling options
           env,                                            # execution environment
           tag,                                            # extra options
           mount, scaling_group, resources, cluster_size,  # resource spec
@@ -801,6 +807,7 @@ def start(image, session_id, owner,                       # base args
                 cluster_size=cluster_size,
                 mounts=mount,
                 envs=envs,
+                startup_command=startup_command,
                 resources=resources,
                 resource_opts=resource_opts,
                 owner_access_key=owner,


### PR DESCRIPTION
This is the client-side counterpart of lablup/backend.ai-manager#199 and lablup/backend.ai#42.
It adds the "result" column and "task ID" column (only displayed with `--show-tid` flag) to the `backend.ai ps` and `backend.ai admin sessions` commands.
It also adds the new `backend.ai task-logs <taskId>` command, which streams the log file directly.
Internally I implemented the `Kernel.get_task_logs()` API function using async generator.

![image](https://user-images.githubusercontent.com/555156/65838582-8aa49f00-e33f-11e9-875d-75b12eea3116.png)
