### PR TITLE
mount vFolder on a custom location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,11 @@
 .idea/
 .*.swp
 *.egg-info/
+.eggs/
 
 __pycache__
 *.py[ocd]
+.mypy_cache/
 
 build/
 sdist/

--- a/src/ai/backend/client/cli/run.py
+++ b/src/ai/backend/client/cli/run.py
@@ -336,8 +336,7 @@ def _prepare_mount_arg(mount):
 @click.option('-m', '--mount', metavar='NAME[=PATH]', type=str, multiple=True,
               help='User-owned virtual folder names to mount. '
                    'If path is not provided, virtual folder will be mounted under /home/work. '
-                   'All virtual folders can only be mounted under /home/work. '
-                   'Virtual folders with a dot prefix in its name will ignore custom mount path.')
+                   'All virtual folders can only be mounted under /home/work. ')
 @click.option('--scaling-group', '--sgroup', type=str, default=None,
               help='The scaling group to execute session. If not specified, '
                    'all available scaling groups are included in the scheduling.')
@@ -761,8 +760,7 @@ def run(image, files, session_id,                          # base args
 @click.option('-m', '--mount', metavar='NAME[=PATH]', type=str, multiple=True,
               help='User-owned virtual folder names to mount. '
                    'If path is not provided, virtual folder will be mounted under /home/work. '
-                   'All virtual folders can only be mounted under /home/work. '
-                   'Virtual folders with a dot prefix in its name will ignore custom mount path.')
+                   'All virtual folders can only be mounted under /home/work. ')
 @click.option('--scaling-group', '--sgroup', type=str, default=None,
               help='The scaling group to execute session. If not specified, '
                    'all available scaling groups are included in the scheduling.')

--- a/src/ai/backend/client/config.py
+++ b/src/ai/backend/client/config.py
@@ -121,7 +121,7 @@ class APIConfig:
     DEFAULTS = {
         'endpoint': 'https://api.backend.ai',
         'endpoint_type': 'api',
-        'version': 'v4.20190615',
+        'version': 'v4.20191119',
         'hash_type': 'sha256',
         'domain': 'default',
         'group': 'default',

--- a/src/ai/backend/client/config.py
+++ b/src/ai/backend/client/config.py
@@ -121,7 +121,7 @@ class APIConfig:
     DEFAULTS = {
         'endpoint': 'https://api.backend.ai',
         'endpoint_type': 'api',
-        'version': 'v4.20191119',
+        'version': 'v5.20191215',
         'hash_type': 'sha256',
         'domain': 'default',
         'group': 'default',

--- a/src/ai/backend/client/kernel.py
+++ b/src/ai/backend/client/kernel.py
@@ -78,6 +78,7 @@ class Kernel:
                             max_wait: int = 0,
                             no_reuse: bool = False,
                             mounts: Iterable[str] = None,
+                            mount_map: Mapping[str, str] = None,
                             envs: Mapping[str, str] = None,
                             startup_command: str = None,
                             resources: Mapping[str, int] = None,
@@ -123,6 +124,10 @@ class Kernel:
             .. versionadded:: 19.09.0
         :param mounts: The list of vfolder names that belongs to the currrent API
             access key.
+        :param mount_map: Mapping which contains custom path to mount vfolder.
+            Key and value of this map should be vfolder name and custom path.
+            All custom mounts should be under /home/work.
+            vFolders which has a dot(.) prefix in its name are not affected.
         :param envs: The environment variables which always bypasses the jail policy.
         :param resources: The resource specification. (TODO: details)
         :param cluster_size: The number of containers in this compute session.
@@ -140,6 +145,8 @@ class Kernel:
             client_token = uuid.uuid4().hex
         if mounts is None:
             mounts = []
+        if mount_map is None:
+            mount_map = {}
         if resources is None:
             resources = {}
         if resource_opts is None:
@@ -157,6 +164,7 @@ class Kernel:
             'clientSessionToken': client_token,
             'config': {
                 'mounts': mounts,
+                'mount_map': mount_map,
                 'environ': envs,
                 'clusterSize': cluster_size,
                 'resources': resources,

--- a/src/ai/backend/client/kernel.py
+++ b/src/ai/backend/client/kernel.py
@@ -164,7 +164,6 @@ class Kernel:
             'clientSessionToken': client_token,
             'config': {
                 'mounts': mounts,
-                'mount_map': mount_map,
                 'environ': envs,
                 'clusterSize': cluster_size,
                 'resources': resources,
@@ -172,6 +171,10 @@ class Kernel:
                 'scalingGroup': scaling_group,
             },
         }
+        if cls.session.config.version >= 'v4.20191119':
+            params['config'].update({
+                'mount_map': mount_map,
+            })
         if cls.session.config.version >= 'v4.20190615':
             params.update({
                 'owner_access_key': owner_access_key,

--- a/src/ai/backend/client/kernel.py
+++ b/src/ai/backend/client/kernel.py
@@ -171,7 +171,7 @@ class Kernel:
                 'scalingGroup': scaling_group,
             },
         }
-        if cls.session.config.version >= 'v4.20191119':
+        if cls.session.config.version >= 'v5.20191215':
             params['config'].update({
                 'mount_map': mount_map,
             })


### PR DESCRIPTION
This PR resolves lablup/backend.ai#69 , by implementing Kernel API's  updated `mount_map` property.

What has changed:
- Default API version updated to `v4.20191119`: check PR lablup/backend.ai-manager#155 for details.
- Kernel API implementation updated to handle new `mount_map` property.
- `start`/`run` command now accepts custom vFolder mount location, so user can select where to mount their vFolders.
  - vFolders can only be mounted under `/home/work`. If not, Backend.AI Agent will return `RuntimeError`. 
  - Setting mount location on dot(.) prefixed vFolders will be ignored by Backend.AI Agent.