### PR TITLE
Added --format and --plain options to the 'backend.ai ps' command

### DIFF
--- a/docs/cli/sessions.rst
+++ b/docs/cli/sessions.rst
@@ -75,7 +75,7 @@ Both commands offer options to specify which fields of sessions should be printe
        ``Max Used Memory (MiB)``, and ``CPU Using (%)``.
 
    * - ``-f``, ``--format``
-     - ``Session ID``, ``Owner``, and specified fields by user.
+     - Specified fields by user.
 
 .. note::
     Fields for ``-f/--format`` option can be displayed by specifying comma-separated parameters.

--- a/docs/cli/sessions.rst
+++ b/docs/cli/sessions.rst
@@ -48,6 +48,45 @@ For other options, please consult the output of ``--help``.
    * - ``--dead``
      - ``CANCELLED`` and ``TERMINATED``.
 
+Both commands offers options to specify which fields of sessions should be printed as follows.
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Option
+     - Included Session Fields
+
+   * - (no option)
+     - ``Session ID``, ``Owner``, ``Image``, ``Type``,
+
+       ``Status``, ``Status Info``, ``Last updated``, and ``Result``.
+
+   * - ``--id-only``
+     - ``Session ID``.
+
+   * - ``--detail``
+     - ``Session ID``, ``Owner``, ``Image``, ``Type``,
+
+       ``Status``, ``Status Info``, ``Last updated``, ``Result``,
+
+       ``Tag``, ``Created At``, ``Occupied Resource``, ``Used Memory (MiB)``,
+
+       ``Max Used Memory (MiB)``, and ``CPU Using (%)``.
+
+   * - ``-f``, ``--format``
+     - ``Session ID``, ``Owner``, and specified fields by user.
+
+.. note::
+    Fields for ``-f/--format`` option can be displayed by specifying comma-separated parameters.
+
+    Available parameters for this option are: ``id``, ``status``, ``status_info``, ``created_at``, ``last_updated``, ``result``, ``image``, ``type``, ``task_id``, ``tag``, ``occupied_slots``, ``used_memory``, ``max_used_memory``, ``cpu_using``.
+
+    For example:
+
+    .. code-block:: shell
+
+        backend.ai admin session --format id,status,cpu_using
 
 .. _simple-execution:
 

--- a/docs/cli/sessions.rst
+++ b/docs/cli/sessions.rst
@@ -28,7 +28,7 @@ other users by adding ``--access-key`` option here.
 
   backend.ai admin sessions
 
-Both commands offers options to set the status filter as follows.
+Both commands offer options to set the status filter as follows.
 For other options, please consult the output of ``--help``.
 
 .. list-table::
@@ -48,7 +48,7 @@ For other options, please consult the output of ``--help``.
    * - ``--dead``
      - ``CANCELLED`` and ``TERMINATED``.
 
-Both commands offers options to specify which fields of sessions should be printed as follows.
+Both commands offer options to specify which fields of sessions should be printed as follows.
 
 .. list-table::
    :widths: 20 80

--- a/src/ai/backend/client/cli/admin/sessions.py
+++ b/src/ai/backend/client/cli/admin/sessions.py
@@ -52,7 +52,7 @@ format_options = {
               help='Display all sessions matching the condition using pagination.')
 @click.option('--detail', is_flag=True, help='Show more details using more columns.')
 @click.option('-f', '--format', default=None,  help='Display only specified fields.')
-@click.option('--plain', is_flag=True, help='Display process status in plain format.')
+@click.option('--plain', is_flag=True, help='Display the session list without decorative line drawings and the header.')
 def sessions(status, access_key, id_only, show_tid, dead, running, all, detail, plain, format):
     '''
     List and manage compute sessions.

--- a/src/ai/backend/client/cli/admin/sessions.py
+++ b/src/ai/backend/client/cli/admin/sessions.py
@@ -71,13 +71,16 @@ def sessions(status, access_key, id_only, show_tid, dead, running, all, detail, 
         pass
     elif format is not None:
         options = format.split(',')
+        if len(options) == 0:
+            print_fail(f'At least one field is required for custom format')
+            sys.exit(1)
         for opt in options:
             if opt not in format_options:
                 print_fail(f'There is no such format option: {opt}')
                 sys.exit(1)
-        fields.extend([
+        fields = [
             format_options[opt] for opt in options
-        ])
+        ]
     else:
         fields.extend([
             ('Image', 'image'),

--- a/src/ai/backend/client/cli/admin/sessions.py
+++ b/src/ai/backend/client/cli/admin/sessions.py
@@ -7,7 +7,26 @@ import textwrap
 from . import admin
 from ...helper import is_admin
 from ...session import Session, is_legacy_server
-from ..pretty import print_error
+from ..pretty import print_error, print_fail
+
+
+# Lets say formattable options are:
+format_options = {
+    'id':              ('Session ID', 'sess_id'),
+    'status':          ('Status', 'status'),
+    'status_info':     ('Status Info', 'status_info'),
+    'created_at':      ('Created At', 'created_at'),
+    'last_updated':    ('Last updated', 'status_changed'),
+    'result':          ('Result', 'result'),
+    'image':           ('Image', 'image'),
+    'type':            ('Type', 'sess_type'),
+    'task_id':         ('Task/Kernel ID', 'id'),
+    'tag':             ('Tag', 'tag'),
+    'occupied_slots':  ('Occupied Resource', 'occupied_slots'),
+    'used_memory':     ('Used Memory (MiB)', 'mem_cur_bytes'),
+    'max_used_memory': ('Max Used Memory (MiB)', 'mem_max_bytes'),
+    'cpu_using':       ('CPU Using (%)', 'cpu_using'),
+}
 
 
 @admin.command()
@@ -32,7 +51,9 @@ from ..pretty import print_error
 @click.option('-a', '--all', is_flag=True,
               help='Display all sessions matching the condition using pagination.')
 @click.option('--detail', is_flag=True, help='Show more details using more columns.')
-def sessions(status, access_key, id_only, show_tid, dead, running, all, detail):
+@click.option('-f', '--format', default=None,  help='Customizable CLI command.')
+@click.option('--plain', is_flag=True, help='Show process status in plain format.')
+def sessions(status, access_key, id_only, show_tid, dead, running, all, detail, plain, format):
     '''
     List and manage compute sessions.
     '''
@@ -46,7 +67,18 @@ def sessions(status, access_key, id_only, show_tid, dead, running, all, detail):
     except Exception as e:
         print_error(e)
         sys.exit(1)
-    if not id_only:
+    if id_only:
+        pass
+    elif format is not None:
+        options = format.split(',')
+        for opt in options:
+            if opt not in format_options:
+                print_fail(f'There is no such format option: {opt}')
+                sys.exit(1)
+        fields.extend([
+            format_options[opt] for opt in options
+        ])
+    else:
         fields.extend([
             ('Image', 'image'),
             ('Type', 'sess_type'),
@@ -140,7 +172,8 @@ def sessions(status, access_key, id_only, show_tid, dead, running, all, detail):
             else:
                 table = tabulate(
                     [item.values() for item in items],
-                    headers=(item[0] for item in fields)
+                    headers=[] if plain else (item[0] for item in fields),
+                    tablefmt="plain" if plain else None
                 )
                 if not is_first:
                     table_rows = table.split('\n')
@@ -171,7 +204,8 @@ def sessions(status, access_key, id_only, show_tid, dead, running, all, detail):
                         print(item['sess_id'])
                 else:
                     print(tabulate([item.values() for item in items],
-                                    headers=(item[0] for item in fields)))
+                                    headers=[] if plain else (item[0] for item in fields),
+                                    tablefmt="plain" if plain else None))
                 if total_count > paginating_interval:
                     print("More sessions can be displayed by using -a/--all option.")
         except Exception as e:

--- a/src/ai/backend/client/cli/admin/sessions.py
+++ b/src/ai/backend/client/cli/admin/sessions.py
@@ -71,9 +71,6 @@ def sessions(status, access_key, id_only, show_tid, dead, running, all, detail, 
         pass
     elif format is not None:
         options = format.split(',')
-        if len(options) == 0:
-            print_fail(f'At least one field is required for custom format')
-            sys.exit(1)
         for opt in options:
             if opt not in format_options:
                 print_fail(f'There is no such format option: {opt}')

--- a/src/ai/backend/client/cli/admin/sessions.py
+++ b/src/ai/backend/client/cli/admin/sessions.py
@@ -51,8 +51,8 @@ format_options = {
 @click.option('-a', '--all', is_flag=True,
               help='Display all sessions matching the condition using pagination.')
 @click.option('--detail', is_flag=True, help='Show more details using more columns.')
-@click.option('-f', '--format', default=None,  help='Customizable CLI command.')
-@click.option('--plain', is_flag=True, help='Show process status in plain format.')
+@click.option('-f', '--format', default=None,  help='Display only specified fields.')
+@click.option('--plain', is_flag=True, help='Display process status in plain format.')
 def sessions(status, access_key, id_only, show_tid, dead, running, all, detail, plain, format):
     '''
     List and manage compute sessions.

--- a/src/ai/backend/client/cli/ps.py
+++ b/src/ai/backend/client/cli/ps.py
@@ -3,6 +3,7 @@ import click
 from . import main
 from .admin.sessions import sessions
 
+
 @main.command()
 @click.option('-s', '--status', default=None,
               type=click.Choice([

--- a/src/ai/backend/client/cli/ps.py
+++ b/src/ai/backend/client/cli/ps.py
@@ -23,7 +23,7 @@ from .admin.sessions import sessions
               help='Display all sessions matching the condition using pagination.')
 @click.option('--detail', is_flag=True, help='Show more details using more columns.')
 @click.option('-f', '--format', default=None,  help='Display only specified fields.')
-@click.option('--plain', is_flag=True, help='Display process status in plain format.')
+@click.option('--plain', is_flag=True, help='Display the session list without decorative line drawings and the header.')
 @click.pass_context
 def ps(ctx, status, id_only, show_tid, dead, running, all, detail, plain, format):
     '''

--- a/src/ai/backend/client/cli/ps.py
+++ b/src/ai/backend/client/cli/ps.py
@@ -3,7 +3,6 @@ import click
 from . import main
 from .admin.sessions import sessions
 
-
 @main.command()
 @click.option('-s', '--status', default=None,
               type=click.Choice([
@@ -23,8 +22,10 @@ from .admin.sessions import sessions
 @click.option('-a', '--all', is_flag=True,
               help='Display all sessions matching the condition using pagination.')
 @click.option('--detail', is_flag=True, help='Show more details using more columns.')
+@click.option('--plain', is_flag=True, help='Show process status in plain format.')
+@click.option('-f', '--format', default=None,  help='Customizable CLI command.')
 @click.pass_context
-def ps(ctx, status, id_only, show_tid, dead, running, all, detail):
+def ps(ctx, status, id_only, show_tid, dead, running, all, detail, plain, format):
     '''
     Lists the current running compute sessions for the current keypair.
     This is an alias of the "admin sessions --status=RUNNING" command.

--- a/src/ai/backend/client/cli/ps.py
+++ b/src/ai/backend/client/cli/ps.py
@@ -22,8 +22,8 @@ from .admin.sessions import sessions
 @click.option('-a', '--all', is_flag=True,
               help='Display all sessions matching the condition using pagination.')
 @click.option('--detail', is_flag=True, help='Show more details using more columns.')
-@click.option('--plain', is_flag=True, help='Show process status in plain format.')
-@click.option('-f', '--format', default=None,  help='Customizable CLI command.')
+@click.option('-f', '--format', default=None,  help='Display only specified fields.')
+@click.option('--plain', is_flag=True, help='Display process status in plain format.')
 @click.pass_context
 def ps(ctx, status, id_only, show_tid, dead, running, all, detail, plain, format):
     '''


### PR DESCRIPTION
lablup/backend.ai#87
@achimnol 

- Added --format/-f options for "backend.ai ps"/"backend.ai admin session" commands
- Added --plain option to see process status info in plain tabular format 

- [ ] I will update the documentation file as soon as possible