### PR TITLE
Add etcd commands for admin

### DIFF
--- a/src/ai/backend/client/cli/admin/__init__.py
+++ b/src/ai/backend/client/cli/admin/__init__.py
@@ -10,7 +10,7 @@ def admin():
 
 def _attach_command():
     from . import (  # noqa
-        agents, domains, groups, images, keypairs, resources, resource_policies,
+        agents, domains, etcd, groups, images, keypairs, resources, resource_policies,
         scaling_groups, sessions, users, vfolders
     )
 

--- a/src/ai/backend/client/cli/admin/etcd.py
+++ b/src/ai/backend/client/cli/admin/etcd.py
@@ -1,0 +1,88 @@
+import json
+import sys
+
+import click
+
+from . import admin
+from ..pretty import print_pretty, print_error, print_fail
+from ...session import Session
+
+
+@admin.group(invoke_without_command=False)
+@click.pass_context
+def etcd(ctx):
+    '''
+    List and manage ETCD configurations.
+    (admin privilege required)
+    '''
+    if ctx.invoked_subcommand is not None:
+        return
+
+
+@etcd.command()
+@click.argument('key', type=str, metavar='KEY')
+@click.option('-p', '--prefix', is_flag=True, default=False,
+              help='Get all keys prefixed with the given key.')
+def get(key, prefix):
+    '''
+    Get a ETCD value(s).
+
+    KEY: Name of ETCD key.
+    '''
+    with Session() as session:
+        try:
+            data = session.EtcdConfig.get(key, prefix)
+        except Exception as e:
+            print_error(e)
+            sys.exit(1)
+        data = json.dumps(data, indent=2) if data else 'null'
+        print_pretty(data)
+
+
+@etcd.command()
+@click.argument('key', type=str, metavar='KEY')
+@click.argument('value', type=str, metavar='VALUE')
+def set(key, value):
+    '''
+    Set new key and value on ETCD.
+
+    KEY: Name of ETCD key.
+    VALUE: Value to set.
+    '''
+    with Session() as session:
+        try:
+            value = json.loads(value)
+            print_pretty('Value converted to a dictionary.')
+        except json.JSONDecodeError:
+            pass
+        try:
+            data = session.EtcdConfig.set(key, value)
+        except Exception as e:
+            print_error(e)
+            sys.exit(1)
+        if data.get('result', False) != 'ok':
+            print_fail('Unable to set key/value.')
+        else:
+            print_pretty('Successfully set key/value.')
+
+
+@etcd.command()
+@click.argument('key', type=str, metavar='KEY')
+@click.option('-p', '--prefix', is_flag=True, default=False,
+              help='Delete all keys prefixed with the given key.')
+def delete(key, prefix):
+    '''
+    Delete key(s) from ETCD.
+
+    KEY: Name of ETCD key.
+    '''
+    with Session() as session:
+        try:
+            data = session.EtcdConfig.delete(key, prefix)
+        except Exception as e:
+            print_error(e)
+            sys.exit(1)
+        if data.get('result', False) != 'ok':
+            print_fail('Unable to delete key/value.')
+        else:
+            print_pretty('Successfully deleted key/value.')

--- a/src/ai/backend/client/func/etcd.py
+++ b/src/ai/backend/client/func/etcd.py
@@ -1,0 +1,74 @@
+from .base import api_function
+from ..request import Request
+
+__all__ = (
+    'EtcdConfig',
+)
+
+
+class EtcdConfig:
+    '''
+    Provides a way to get or set ETCD configurations.
+
+    .. note::
+
+      All methods in this function class require your API access key to
+      have the *superadmin* privilege.
+    '''
+
+    session = None
+    '''The client session instance that this function class is bound to.'''
+
+    @api_function
+    @classmethod
+    async def get(cls, key: str, prefix: bool = False) -> dict:
+        '''
+        Get configuration from ETCD with given key.
+
+        :param key: Name of the key to fetch.
+        :param prefix: get all keys prefixed with the give key.
+        '''
+        rqst = Request(cls.session, 'POST', '/config/get')
+        rqst.set_json({
+            'key': key,
+            'prefix': prefix,
+        })
+        async with rqst.fetch() as resp:
+            data = await resp.json()
+            return data.get('result', None)
+
+    @api_function
+    @classmethod
+    async def set(cls, key: str, value: str) -> dict:
+        '''
+        Set configuration into ETCD with given key and value.
+
+        :param key: Name of the key to set.
+        :param value: Value to set.
+        '''
+        rqst = Request(cls.session, 'POST', '/config/set')
+        rqst.set_json({
+            'key': key,
+            'value': value,
+        })
+        async with rqst.fetch() as resp:
+            data = await resp.json()
+            return data
+
+    @api_function
+    @classmethod
+    async def delete(cls, key: str, prefix: bool = False) -> dict:
+        '''
+        Delete configuration from ETCD with given key.
+
+        :param key: Name of the key to delete.
+        :param prefix: delete all keys prefixed with the give key.
+        '''
+        rqst = Request(cls.session, 'POST', '/config/delete')
+        rqst.set_json({
+            'key': key,
+            'prefix': prefix,
+        })
+        async with rqst.fetch() as resp:
+            data = await resp.json()
+            return data

--- a/src/ai/backend/client/session.py
+++ b/src/ai/backend/client/session.py
@@ -113,6 +113,7 @@ class BaseSession(metaclass=abc.ABCMeta):
         'Agent', 'AgentWatcher', 'ScalingGroup',
         'Image', 'ComputeSession', 'SessionTemplate',
         'Domain', 'Group', 'Auth', 'User', 'KeyPair',
+        'EtcdConfig',
         'Resource', 'KeypairResourcePolicy',
         'VFolder',
     )
@@ -177,6 +178,7 @@ class Session(BaseSession):
         from .func.admin import Admin
         from .func.agent import Agent, AgentWatcher
         from .func.auth import Auth
+        from .func.etcd import EtcdConfig
         from .func.domain import Domain
         from .func.group import Group
         from .func.image import Image
@@ -232,6 +234,15 @@ class Session(BaseSession):
         })
         '''
         The :class:`~ai.backend.client.Auth` function proxy
+        bound to this session.
+        '''
+
+        self.EtcdConfig = type('EtcdConfig', (BaseFunction, ), {
+            **EtcdConfig.__dict__,
+            'session': self,
+        })
+        '''
+        The :class:`~ai.backend.client.EtcdConfig` function proxy
         bound to this session.
         '''
 
@@ -400,6 +411,7 @@ class AsyncSession(BaseSession):
         from .func.admin import Admin
         from .func.agent import Agent, AgentWatcher
         from .func.auth import Auth
+        from .func.etcd import EtcdConfig
         from .func.group import Group
         from .func.image import Image
         from .func.session import ComputeSession
@@ -454,6 +466,15 @@ class AsyncSession(BaseSession):
         })
         '''
         The :class:`~ai.backend.client.Auth` function proxy
+        bound to this session.
+        '''
+
+        self.EtcdConfig = type('EtcdConfig', (BaseFunction, ), {
+            **EtcdConfig.__dict__,
+            'session': self,
+        })
+        '''
+        The :class:`~ai.backend.client.EtcdConfig` function proxy
         bound to this session.
         '''
 


### PR DESCRIPTION
### Usage

* Get a key/value pair:
   - `backend.ai admin etcd get <key>`
* Get all key/value pairs prefixed with given key:
   - `backend.ai admin etcd get --prefix <key>`
* Set a key/value pair:
   - `backend.ai admin etcd set <key> <value>`
* Set a key/value pair with value as a dict:
   - `backend.ai admin etcd set <key> '<stringified-json-value>'`
   - If value is not json-parsable, single key/value will be set.
* Delete a key/value pair:
   - `backend.ai admin etcd delete <key>`
* Delete all key/value pairs prefixed with given key:
   - `backend.ai admin etcd delete --prefix <key>`