### PR TITLE
feat: purge command for users, groups, and domains

### DIFF
--- a/changes/117.feature
+++ b/changes/117.feature
@@ -1,0 +1,1 @@
+Add purge command for users, groups, and domains.

--- a/src/ai/backend/client/cli/admin/domains.py
+++ b/src/ai/backend/client/cli/admin/domains.py
@@ -4,7 +4,8 @@ import click
 from tabulate import tabulate
 
 from . import admin
-from ..pretty import print_error, print_fail
+from ..interaction import ask_yn
+from ..pretty import print_error, print_info, print_fail
 from ...session import Session
 
 
@@ -178,6 +179,9 @@ def purge(name):
     """
     with Session() as session:
         try:
+            if not ask_yn():
+                print_info('Cancelled')
+                sys.exit(1)
             data = session.Domain.purge(name)
         except Exception as e:
             print_error(e)

--- a/src/ai/backend/client/cli/admin/domains.py
+++ b/src/ai/backend/client/cli/admin/domains.py
@@ -152,13 +152,33 @@ def update(name, new_name, description, is_active, total_resource_slots,
 @click.argument('name', type=str, metavar='NAME')
 def delete(name):
     """
+    Inactive an existing domain.
+
+    NAME: Name of a domain to inactive.
+    """
+    with Session() as session:
+        try:
+            data = session.Domain.delete(name)
+        except Exception as e:
+            print_error(e)
+            sys.exit(1)
+        if not data['ok']:
+            print_fail('Domain inactivation has failed: {0}'.format(data['msg']))
+            sys.exit(1)
+        print('Domain is inactivated: ' + name + '.')
+
+
+@domains.command()
+@click.argument('name', type=str, metavar='NAME')
+def purge(name):
+    """
     Delete an existing domain.
 
     NAME: Name of a domain to delete.
     """
     with Session() as session:
         try:
-            data = session.Domain.delete(name)
+            data = session.Domain.purge(name)
         except Exception as e:
             print_error(e)
             sys.exit(1)

--- a/src/ai/backend/client/cli/admin/groups.py
+++ b/src/ai/backend/client/cli/admin/groups.py
@@ -4,6 +4,7 @@ import click
 from tabulate import tabulate
 
 from . import admin
+from ..interaction import ask_yn
 from ..pretty import print_error, print_fail
 from ...session import Session
 
@@ -157,13 +158,36 @@ def update(gid, name, description, is_active, total_resource_slots,
 @click.argument('gid', type=str, metavar='GROUP_ID')
 def delete(gid):
     """
-    Delete an existing group.
+    Inactivates the existing group. Does not actually delete it for safety.
 
-    GROUP_ID: Group ID to delete.
+    GROUP_ID: Group ID to inactivate.
     """
     with Session() as session:
         try:
             data = session.Group.delete(gid)
+        except Exception as e:
+            print_error(e)
+            sys.exit(1)
+        if not data['ok']:
+            print_fail('Group inactivation has failed: {0}'.format(data['msg']))
+            sys.exit(1)
+        print('Group is inactivated: ' + gid + '.')
+
+
+@groups.command()
+@click.argument('gid', type=str, metavar='GROUP_ID')
+def purge(gid):
+    """
+    Delete the existing group. This action cannot be undone.
+
+    GROUP_ID: Group ID to inactivate.
+    """
+    with Session() as session:
+        try:
+            if not ask_yn():
+                print_info('Cancelled')
+                sys.exit(1)
+            data = session.Group.purge(gid)
         except Exception as e:
             print_error(e)
             sys.exit(1)

--- a/src/ai/backend/client/cli/admin/groups.py
+++ b/src/ai/backend/client/cli/admin/groups.py
@@ -5,7 +5,7 @@ from tabulate import tabulate
 
 from . import admin
 from ..interaction import ask_yn
-from ..pretty import print_error, print_fail
+from ..pretty import print_error, print_info, print_fail
 from ...session import Session
 
 

--- a/src/ai/backend/client/cli/admin/users.py
+++ b/src/ai/backend/client/cli/admin/users.py
@@ -5,14 +5,14 @@ from tabulate import tabulate
 
 from . import admin
 from ...session import Session
-from ..pretty import print_error, print_fail
+from ..interaction import ask_yn
+from ..pretty import print_error, print_info, print_fail
 from ..pagination import (
     get_preferred_page_size,
     echo_via_pager,
     tabulate_items,
 )
 from ...exceptions import NoItems
-
 
 @admin.command()
 @click.option('-e', '--email', type=str, default=None,
@@ -191,13 +191,40 @@ def update(email, password, username, full_name, domain_name, role, status,
 @click.argument('email', type=str, metavar='EMAIL')
 def delete(email):
     """
-    Delete an existing user.
+    Inactivate an existing user.
 
-    EMAIL: Email of user to delete.
+    EMAIL: Email of user to inactivate.
     """
     with Session() as session:
         try:
             data = session.User.delete(email)
+        except Exception as e:
+            print_error(e)
+            sys.exit(1)
+        if not data['ok']:
+            print_fail('User inactivation has failed: {0}'.format(data['msg']))
+            sys.exit(1)
+        print('User is inactivated: ' + email + '.')
+
+
+@users.command()
+@click.argument('email', type=str, metavar='EMAIL')
+@click.option('--purge-shared-vfolders', is_flag=True, default=False,
+              help='Delete user\'s all virtual folders. '
+                   'If False, shared folders will not be deleted '
+                   'and migrated the ownership to the requested admin.')
+def purge(email, purge_shared_vfolders):
+    """
+    Delete an existing user. This action cannot be undone.
+
+    NAME: Name of a domain to delete.
+    """
+    with Session() as session:
+        try:
+            if not ask_yn():
+                print_info('Cancelled')
+                sys.exit(1)
+            data = session.User.purge(email, purge_shared_vfolders)
         except Exception as e:
             print_error(e)
             sys.exit(1)

--- a/src/ai/backend/client/cli/admin/users.py
+++ b/src/ai/backend/client/cli/admin/users.py
@@ -14,6 +14,7 @@ from ..pagination import (
 )
 from ...exceptions import NoItems
 
+
 @admin.command()
 @click.option('-e', '--email', type=str, default=None,
               help='Email of a user to display.')

--- a/src/ai/backend/client/func/domain.py
+++ b/src/ai/backend/client/func/domain.py
@@ -163,7 +163,7 @@ class Domain(BaseFunction):
     @classmethod
     async def delete(cls, name: str):
         """
-        Deletes an existing domain.
+        Inactivates an existing domain.
         """
         query = textwrap.dedent("""\
             mutation($name: String!) {
@@ -181,3 +181,26 @@ class Domain(BaseFunction):
         async with rqst.fetch() as resp:
             data = await resp.json()
             return data['delete_domain']
+
+    @api_function
+    @classmethod
+    async def purge(cls, name: str):
+        """
+        Deletes an existing domain.
+        """
+        query = textwrap.dedent("""\
+            mutation($name: String!) {
+                purge_domain(name: $name) {
+                    ok msg
+                }
+            }
+        """)
+        variables = {'name': name}
+        rqst = Request(api_session.get(), 'POST', '/admin/graphql')
+        rqst.set_json({
+            'query': query,
+            'variables': variables,
+        })
+        async with rqst.fetch() as resp:
+            data = await resp.json()
+            return data['purge_domain']

--- a/src/ai/backend/client/func/group.py
+++ b/src/ai/backend/client/func/group.py
@@ -163,7 +163,7 @@ class Group(BaseFunction):
     @classmethod
     async def delete(cls, gid: str):
         """
-        Deletes an existing group.
+        Inactivates the existing group. Does not actually delete it for safety.
         """
         query = textwrap.dedent("""\
             mutation($gid: UUID!) {
@@ -181,6 +181,29 @@ class Group(BaseFunction):
         async with rqst.fetch() as resp:
             data = await resp.json()
         return data['delete_group']
+
+    @api_function
+    @classmethod
+    async def purge(cls, gid: str):
+        """
+        Delete the existing group. This action cannot be undone.
+        """
+        query = textwrap.dedent("""\
+            mutation($gid: UUID!) {
+                purge_group(gid: $gid) {
+                    ok msg
+                }
+            }
+        """)
+        variables = {'gid': gid}
+        rqst = Request(api_session.get(), 'POST', '/admin/graphql')
+        rqst.set_json({
+            'query': query,
+            'variables': variables,
+        })
+        async with rqst.fetch() as resp:
+            data = await resp.json()
+        return data['purge_group']
 
     @api_function
     @classmethod


### PR DESCRIPTION
This PR adds purge commands to delete users, groups, and domains.

How to use:
```shell
backend.ai admin users purge <email>
backend.ai admin groups purge <group-id>
backend.ai admin domains purge <domain-name>
```

Related Issue: lablup/backend.ai-manager#302
Related: OP#651