### PR TITLE
fix: user_id filter is missing in paginated keypair list

### DIFF
--- a/changes/119.fix
+++ b/changes/119.fix
@@ -1,0 +1,1 @@
+Extends the keypair's `paginated_list` query to accept `user_id` parameter.

--- a/src/ai/backend/client/func/keypair.py
+++ b/src/ai/backend/client/func/keypair.py
@@ -175,6 +175,7 @@ class KeyPair(BaseFunction):
         is_active: bool = None,
         domain_name: str = None,
         *,
+        user_id: Union[int, str] = None,
         fields: Sequence[str] = _default_list_fields,
         page_size: int = 20,
     ) -> AsyncIterator[dict]:
@@ -182,12 +183,16 @@ class KeyPair(BaseFunction):
         Lists the keypairs.
         You need an admin privilege for this operation.
         """
+        variables = {
+            'is_active': (is_active, 'Boolean'),
+            'domain_name': (domain_name, 'String'),
+        }
+        if user_id is not None:
+            uid_type = 'Int' if isinstance(user_id, int) else 'String!'
+            variables['email'] = (user_id, uid_type)
         async for item in generate_paginated_results(
             'keypair_list',
-            {
-                'is_active': (is_active, 'Boolean'),
-                'domain_name': (domain_name, 'String'),
-            },
+            variables,
             fields,
             page_size=page_size,
         ):

--- a/src/ai/backend/client/func/keypair.py
+++ b/src/ai/backend/client/func/keypair.py
@@ -175,7 +175,7 @@ class KeyPair(BaseFunction):
         is_active: bool = None,
         domain_name: str = None,
         *,
-        user_id: Union[int, str] = None,
+        user_id: str = None,
         fields: Sequence[str] = _default_list_fields,
         page_size: int = 20,
     ) -> AsyncIterator[dict]:
@@ -188,8 +188,7 @@ class KeyPair(BaseFunction):
             'domain_name': (domain_name, 'String'),
         }
         if user_id is not None:
-            uid_type = 'Int' if isinstance(user_id, int) else 'String!'
-            variables['email'] = (user_id, uid_type)
+            variables['email'] = (user_id, 'String')
         async for item in generate_paginated_results(
             'keypair_list',
             variables,


### PR DESCRIPTION
`user_id` filter is missing in keypair's `paginated_list` query. It exists in `list` query. So, this PR just extends the `paginated_list` query to accept `user_id` parameter.

Related: lablup/backend.ai-manager-hub#49, OP#668.