### PR TITLE
feat: display full_name when querying keypair(s)

### DIFF
--- a/changes/122.feature
+++ b/changes/122.feature
@@ -1,0 +1,1 @@
+Display users' full name when querying keypair(s).

--- a/src/ai/backend/client/cli/admin/keypairs.py
+++ b/src/ai/backend/client/cli/admin/keypairs.py
@@ -84,7 +84,6 @@ def keypairs(ctx, user_id, is_active):
     except (TypeError, ValueError):
         pass  # string-based user ID for Backend.AI v1.4+
 
-
     def format_item(item):
         full_name = item['user_info'].get('full_name', '')
         item['user_info'] = full_name


### PR DESCRIPTION
Some customers want to see the user's `full_name` in keypair query. So, This PR supports it.

Related: https://github.com/lablup/backend.ai-manager/pull/313.
Internal ticket: OP#672.