### PR TITLE
feat: add command to share/unshare group virtual folders to users

### DIFF
--- a/changes/159.feature
+++ b/changes/159.feature
@@ -1,0 +1,1 @@
+Add commands to share/unshare a group virtual folder directly to specific users. This is to allow specified users (usually teachers with user account) can upload data/materials to a virtual folder while it is shared as read-only for other group users.

--- a/src/ai/backend/client/func/vfolder.py
+++ b/src/ai/backend/client/func/vfolder.py
@@ -386,6 +386,24 @@ class VFolder(BaseFunction):
             return await resp.json()
 
     @api_function
+    async def share(self, perm: str, emails: Sequence[str]):
+        rqst = Request('POST', '/folders/{}/share'.format(self.name))
+        rqst.set_json({
+            'permission': perm, 'emails': emails,
+        })
+        async with rqst.fetch() as resp:
+            return await resp.json()
+
+    @api_function
+    async def unshare(self, emails: Sequence[str]):
+        rqst = Request('DELETE', '/folders/{}/unshare'.format(self.name))
+        rqst.set_json({
+            'emails': emails,
+        })
+        async with rqst.fetch() as resp:
+            return await resp.json()
+
+    @api_function
     async def leave(self):
         rqst = Request('POST', '/folders/{}/leave'.format(self.name))
         async with rqst.fetch() as resp:


### PR DESCRIPTION
This PR adds commands to share or unshare a group virtual folder to users directly with overriding permission. This is to allow specified users (usually teachers with user account) can upload data/materials to a group virtual folder while it is shared as read-only for other group users (usually students).

How to use:
```console
$ backend.ai vfolder share -p wd my_group_folder user@lablup.com friend@lablup.com
Shared with wd permission to:
        - user@lablup.com
        - friend@lablup.com
$ backend.ai vfolder unshare my_group_folder user@lablup.com friend@lablup.com
Unshared from:
        - user@lablup.com
        - friend@lablup.com
```

Related: https://github.com/lablup/backend.ai-manager/pull/419