### PR TITLE
fix: Handling default values in JSONParamType

### DIFF
--- a/changes/180.fix
+++ b/changes/180.fix
@@ -1,0 +1,1 @@
+Fix handling of default values for JSON string CLI arugments (`client.cli.params.JSONParamType`)

--- a/src/ai/backend/client/cli/admin/scaling_group.py
+++ b/src/ai/backend/client/cli/admin/scaling_group.py
@@ -75,11 +75,11 @@ def list(ctx: CLIContext) -> None:
               help='New scaling group will be inactive.')
 @click.option('--driver', type=str, default='static',
               help='Set driver.')
-@click.option('--driver-opts', type=JSONParamType(), default={},
+@click.option('--driver-opts', type=JSONParamType(), default='{}',
               help='Set driver options as a JSON string.')
 @click.option('--scheduler', type=str, default='fifo',
               help='Set scheduler.')
-@click.option('--scheduler-opts', type=JSONParamType(), default={},
+@click.option('--scheduler-opts', type=JSONParamType(), default='{}',
               help='Set scheduler options as a JSON string.')
 def add(name, description, inactive,
         driver, driver_opts, scheduler, scheduler_opts):

--- a/src/ai/backend/client/cli/params.py
+++ b/src/ai/backend/client/cli/params.py
@@ -55,14 +55,31 @@ class ByteSizeParamCheckType(ByteSizeParamType):
 
 
 class JSONParamType(click.ParamType):
+    """
+    A JSON string parameter type.
+    The default value must be given as a valid JSON-parsable string,
+    not the Python objects.
+    """
+
     name = "json-string"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._parsed = False
 
     def convert(
         self,
-        value: str,
+        value: Optional[str],
         param: Optional[click.Parameter],
         ctx: Optional[click.Context],
     ) -> Any:
+        if self._parsed:
+            # Click invokes this method TWICE
+            # for a default value given as string.
+            return value
+        self._parsed = True
+        if value is None:
+            return None
         try:
             return json.loads(value)
         except json.JSONDecodeError:

--- a/src/ai/backend/client/func/scaling_group.py
+++ b/src/ai/backend/client/func/scaling_group.py
@@ -164,9 +164,9 @@ class ScalingGroup(BaseFunction):
                 'description': description,
                 'is_active': is_active,
                 'driver': driver,
-                'driver_opts': json.dumps(driver_opts),
+                'driver_opts': None if driver_opts is None else json.dumps(driver_opts),
                 'scheduler': scheduler,
-                'scheduler_opts': json.dumps(scheduler_opts),
+                'scheduler_opts': None if scheduler_opts is None else json.dumps(scheduler_opts),
             },
         }
         data = await api_session.get().Admin._query(query, variables)


### PR DESCRIPTION
This is follow-up to #163.

* Click invokes ParamType.convert() method *twice* for string default values,
  which is unfortunately indistinguishable by the type as the official doc says
  when the user passes a signle JSON string literal.
