### PR TITLE
feat: Add support for session renaming

### DIFF
--- a/changes/189.feature
+++ b/changes/189.feature
@@ -1,0 +1,1 @@
+add support for session name renaming

--- a/changes/189.feature
+++ b/changes/189.feature
@@ -1,1 +1,1 @@
-add support for session name renaming
+Add support for session renaming

--- a/src/ai/backend/client/cli/session.py
+++ b/src/ai/backend/client/cli/session.py
@@ -637,6 +637,28 @@ def logs(session_id):
             sys.exit(1)
 
 
+@session.command()
+@click.argument('session_id', metavar='SESSID')
+@click.argument('new_id', metavar='NEWID')
+def rename(session_id, new_id):
+    '''
+    Renames session name of running session.
+
+    \b
+    SESSID: Session ID or its alias given when creating the session.
+    NEWID: New Session ID to rename to.
+    '''
+
+    with Session() as session:
+        try:
+            kernel = session.ComputeSession(session_id)
+            kernel.rename(new_id)
+            print_done(f'Session renamed to {new_id}.')
+        except Exception as e:
+            print_error(e)
+            sys.exit(1)
+
+
 def _ssh_cmd(docs: str = None):
 
     @click.argument("session_ref",  type=str, metavar='SESSION_REF')

--- a/src/ai/backend/client/func/session.py
+++ b/src/ai/backend/client/func/session.py
@@ -528,7 +528,7 @@ class ComputeSession(BaseFunction):
         )
         async with rqst.fetch():
             pass
-    
+
     @api_function
     async def rename(self, new_id):
         """

--- a/src/ai/backend/client/func/session.py
+++ b/src/ai/backend/client/func/session.py
@@ -528,6 +528,22 @@ class ComputeSession(BaseFunction):
         )
         async with rqst.fetch():
             pass
+    
+    @api_function
+    async def rename(self, new_id):
+        """
+        Renames Session ID of running compute session.
+        """
+        params = {'name': new_id}
+        if self.owner_access_key:
+            params['owner_access_key'] = self.owner_access_key
+        prefix = get_naming(api_session.get().api_version, 'path')
+        rqst = Request(
+            'POST', f'/{prefix}/{self.name}/rename',
+            params=params,
+        )
+        async with rqst.fetch():
+            pass
 
     @api_function
     async def interrupt(self):


### PR DESCRIPTION
This PR adds new rename_session API, as described on lablup/backend.ai#296.