### PR TITLE
feat: implement retry in vfolder file download

### DIFF
--- a/src/ai/backend/client/func/vfolder.py
+++ b/src/ai/backend/client/func/vfolder.py
@@ -279,8 +279,8 @@ class VFolder(BaseFunction):
                             raise BackendClientError(msg) from e
                         retry_config['retry_cnt'] = cast(int, retry_config['retry_cnt']) + 1
                         retry_hdrs['If-Range'] = cast(str, retry_config['ir_validator'])
-                        retry_hdrs['Range'] = f'{retry_config["range_unit"]}'
-                        '={retry_config["content_range"]}-'
+                        retry_hdrs['Range'] = f'{retry_config["range_unit"]}' \
+                            f'={retry_config["content_range"]}-'
                         retry_config['is_retry'] = True
                         continue
                     except aiohttp.ClientResponseError as e:

--- a/upload_file.txt
+++ b/upload_file.txt
@@ -1,0 +1,2 @@
+test one,
+test two, test three


### PR DESCRIPTION
resolves https://github.com/lablup/backend.ai/issues/339

implement retry feature in folder file download by range request.
it retries only when `aiohttp.ClientConnectionError` occurs. else just raise the error with message.
the default retry count is 3.