### PR TITLE
fix: add backup file suffix not to make error in sed command.

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -131,7 +131,7 @@ jobs:
         set +e
         git ls-remote --heads 'https://github.com/lablup/backend.ai-cli' | grep -q "refs/heads/${GHBRANCH}"
         if [ $? -eq 0 ]; then
-          sed -i "s%\(backend.ai-cli\)@main%\1@${GHBRANCH}%" requirements/${REQUIREMENTS_FILE}.txt
+          sed -i.bak "s%\(backend.ai-cli\)@main%\1@${GHBRANCH}%" requirements/${REQUIREMENTS_FILE}.txt
         fi
         set -e
         python -m pip install -U -r requirements/${REQUIREMENTS_FILE}.txt

--- a/changes/202.fix
+++ b/changes/202.fix
@@ -1,0 +1,1 @@
+Append backup file extension in sed command not to make error when tests on macOS.

--- a/changes/202.fix
+++ b/changes/202.fix
@@ -1,1 +1,1 @@
-Append backup file extension in sed command not to make error when tests on macOS.
+Append a backup file extension to the `-i` option of `sed` command to prevent branch substitution errors when tested on macOS


### PR DESCRIPTION
* Append backup file extension on sed command not to make error when tests on macOS.