### PR TITLE
fix: edit help text about arbitrary vfolder path mounting

### DIFF
--- a/changes/204.fix
+++ b/changes/204.fix
@@ -1,0 +1,1 @@
+Edit user text message about arbitrary path using. 

--- a/changes/204.fix
+++ b/changes/204.fix
@@ -1,1 +1,1 @@
-Edit user text message about arbitrary path using. 
+Update the docs and help texts of vfolder mount options to reflect allowance of arbitrary paths.

--- a/docs/cli/storage.rst
+++ b/docs/cli/storage.rst
@@ -93,7 +93,7 @@ the "mydata1" virtual folder.
 
 In your code, you may access the virtual folder via ``/home/work/mydata1``
 (where the default current working directory is ``/home/work``) just like
-a normal directory. If you want to mount vfolders in other path, add '/'
+a normal directory.  If you want to mount vfolders in other path, add '/'
 as prefix at the forefont of the vfolder path.
 
 By reusing the same vfolder in subsequent sessions, you do not have to

--- a/docs/cli/storage.rst
+++ b/docs/cli/storage.rst
@@ -93,7 +93,8 @@ the "mydata1" virtual folder.
 
 In your code, you may access the virtual folder via ``/home/work/mydata1``
 (where the default current working directory is ``/home/work``) just like
-a normal directory.
+a normal directory. If you want to mount vfolders in other path, add '/'
+as prefix at the forefont of the vfolder path.
 
 By reusing the same vfolder in subsequent sessions, you do not have to
 donwload the result and upload it as the input for next sessions, just

--- a/src/ai/backend/client/cli/run.py
+++ b/src/ai/backend/client/cli/run.py
@@ -320,9 +320,9 @@ def prepare_mount_arg(
               help='User-owned virtual folder names to mount. '
                    'If path is not provided, virtual folder will be mounted under /home/work. '
                    'When the target path is relative, it is placed under /home/work '
-	               'with auto-created parent directories if any. '
-	               'Absolute paths are mounted as-is, but it is prohibited to '
-	               'override the predefined Linux system directories.')
+                   'with auto-created parent directories if any. '
+                   'Absolute paths are mounted as-is, but it is prohibited to '
+                   'override the predefined Linux system directories.')
 @click.option('--scaling-group', '--sgroup', type=str, default=None,
               help='The scaling group to execute session. If not specified, '
                    'all available scaling groups are included in the scheduling.')

--- a/src/ai/backend/client/cli/run.py
+++ b/src/ai/backend/client/cli/run.py
@@ -319,7 +319,9 @@ def prepare_mount_arg(
               metavar='NAME[=PATH]', type=str, multiple=True,
               help='User-owned virtual folder names to mount. '
                    'If path is not provided, virtual folder will be mounted under /home/work. '
-                   'All virtual folders can only be mounted under /home/work. ')
+                   'Relative paths are under /home/work. '
+                   'If you want different paths, names should be absolute paths. '
+                   'Please use different path from the linux system folders. ')
 @click.option('--scaling-group', '--sgroup', type=str, default=None,
               help='The scaling group to execute session. If not specified, '
                    'all available scaling groups are included in the scheduling.')

--- a/src/ai/backend/client/cli/run.py
+++ b/src/ai/backend/client/cli/run.py
@@ -319,9 +319,10 @@ def prepare_mount_arg(
               metavar='NAME[=PATH]', type=str, multiple=True,
               help='User-owned virtual folder names to mount. '
                    'If path is not provided, virtual folder will be mounted under /home/work. '
-                   'Relative paths are under /home/work. '
-                   'If you want different paths, names should be absolute paths. '
-                   'Please use different path from the linux system folders. ')
+                   'When the target path is relative, it is placed under /home/work '
+	               'with auto-created parent directories if any. '
+	               'Absolute paths are mounted as-is, but it is prohibited to '
+	               'override the predefined Linux system directories.')
 @click.option('--scaling-group', '--sgroup', type=str, default=None,
               help='The scaling group to execute session. If not specified, '
                    'all available scaling groups are included in the scheduling.')

--- a/src/ai/backend/client/cli/session.py
+++ b/src/ai/backend/client/cli/session.py
@@ -260,9 +260,9 @@ def _create_from_template_cmd(docs: str = None):
     @click.option('-m', '--mount', metavar='NAME[=PATH]', type=str, multiple=True,
                   help='User-owned virtual folder names to mount. '
                        'When the target path is relative, it is placed under /home/work '
-	                   'with auto-created parent directories if any. '
-	                   'Absolute paths are mounted as-is, but it is prohibited to '
-	                   'override the predefined Linux system directories.')
+                       'with auto-created parent directories if any. '
+                       'Absolute paths are mounted as-is, but it is prohibited to '
+                       'override the predefined Linux system directories.')
     @click.option('--scaling-group', '--sgroup', type=str, default=undefined,
                   help='The scaling group to execute session. If not specified, '
                        'all available scaling groups are included in the scheduling.')

--- a/src/ai/backend/client/cli/session.py
+++ b/src/ai/backend/client/cli/session.py
@@ -68,9 +68,9 @@ def _create_cmd(docs: str = None):
                   help='User-owned virtual folder names to mount. '
                        'If path is not provided, virtual folder will be mounted under /home/work. '
                        'When the target path is relative, it is placed under /home/work '
-	                   'with auto-created parent directories if any. '
-	                   'Absolute paths are mounted as-is, but it is prohibited to '
-	                   'override the predefined Linux system directories.')
+                       'with auto-created parent directories if any. '
+                       'Absolute paths are mounted as-is, but it is prohibited to '
+                       'override the predefined Linux system directories.')
     @click.option('--scaling-group', '--sgroup', type=str, default=None,
                   help='The scaling group to execute session. If not specified, '
                        'all available scaling groups are included in the scheduling.')

--- a/src/ai/backend/client/cli/session.py
+++ b/src/ai/backend/client/cli/session.py
@@ -67,7 +67,9 @@ def _create_cmd(docs: str = None):
                   metavar='NAME[=PATH]', type=str, multiple=True,
                   help='User-owned virtual folder names to mount. '
                        'If path is not provided, virtual folder will be mounted under /home/work. '
-                       'All virtual folders can only be mounted under /home/work. ')
+                       'Relative paths are under /home/work. '
+                       'If you want different paths, names should be absolute paths. '
+                       'Please use different path from the linux system folders.')
     @click.option('--scaling-group', '--sgroup', type=str, default=None,
                   help='The scaling group to execute session. If not specified, '
                        'all available scaling groups are included in the scheduling.')
@@ -257,7 +259,7 @@ def _create_from_template_cmd(docs: str = None):
     @click.option('-m', '--mount', metavar='NAME[=PATH]', type=str, multiple=True,
                   help='User-owned virtual folder names to mount. '
                        'If path is not provided, virtual folder will be mounted under /home/work. '
-                       'All virtual folders can only be mounted under /home/work. ')
+                       'Please use different path from the linux system folders. ')
     @click.option('--scaling-group', '--sgroup', type=str, default=undefined,
                   help='The scaling group to execute session. If not specified, '
                        'all available scaling groups are included in the scheduling.')

--- a/src/ai/backend/client/cli/session.py
+++ b/src/ai/backend/client/cli/session.py
@@ -67,9 +67,10 @@ def _create_cmd(docs: str = None):
                   metavar='NAME[=PATH]', type=str, multiple=True,
                   help='User-owned virtual folder names to mount. '
                        'If path is not provided, virtual folder will be mounted under /home/work. '
-                       'Relative paths are under /home/work. '
-                       'If you want different paths, names should be absolute paths. '
-                       'Please use different path from the linux system folders.')
+                       'When the target path is relative, it is placed under /home/work '
+	                   'with auto-created parent directories if any. '
+	                   'Absolute paths are mounted as-is, but it is prohibited to '
+	                   'override the predefined Linux system directories.')
     @click.option('--scaling-group', '--sgroup', type=str, default=None,
                   help='The scaling group to execute session. If not specified, '
                        'all available scaling groups are included in the scheduling.')
@@ -258,8 +259,10 @@ def _create_from_template_cmd(docs: str = None):
     # resource spec
     @click.option('-m', '--mount', metavar='NAME[=PATH]', type=str, multiple=True,
                   help='User-owned virtual folder names to mount. '
-                       'If path is not provided, virtual folder will be mounted under /home/work. '
-                       'Please use different path from the linux system folders. ')
+                       'When the target path is relative, it is placed under /home/work '
+	                   'with auto-created parent directories if any. '
+	                   'Absolute paths are mounted as-is, but it is prohibited to '
+	                   'override the predefined Linux system directories.')
     @click.option('--scaling-group', '--sgroup', type=str, default=undefined,
                   help='The scaling group to execute session. If not specified, '
                        'all available scaling groups are included in the scheduling.')

--- a/src/ai/backend/client/func/session.py
+++ b/src/ai/backend/client/func/session.py
@@ -218,7 +218,9 @@ class ComputeSession(BaseFunction):
             access key.
         :param mount_map: Mapping which contains custom path to mount vfolder.
             Key and value of this map should be vfolder name and custom path.
-            All custom mounts should be under /home/work.
+            Defalut mounts or relative paths are under /home/work.
+            If you want different paths, names should be absolute paths.
+            vFolders should have different name from linux system folders.
             vFolders which has a dot(.) prefix in its name are not affected.
         :param envs: The environment variables which always bypasses the jail policy.
         :param resources: The resource specification. (TODO: details)
@@ -387,7 +389,9 @@ class ComputeSession(BaseFunction):
             access key.
         :param mount_map: Mapping which contains custom path to mount vfolder.
             Key and value of this map should be vfolder name and custom path.
-            All custom mounts should be under /home/work.
+            Defalut mounts or relative paths are under /home/work.
+            If you want different paths, names should be absolute paths.
+            vFolders should have different name from linux system folders.
             vFolders which has a dot(.) prefix in its name are not affected.
         :param envs: The environment variables which always bypasses the jail policy.
         :param resources: The resource specification. (TODO: details)

--- a/src/ai/backend/client/func/session.py
+++ b/src/ai/backend/client/func/session.py
@@ -220,7 +220,7 @@ class ComputeSession(BaseFunction):
             Key and value of this map should be vfolder name and custom path.
             Defalut mounts or relative paths are under /home/work.
             If you want different paths, names should be absolute paths.
-            vFolders should have different name from linux system folders.
+            The target mount path of vFolders should not overlap with the linux system folders.
             vFolders which has a dot(.) prefix in its name are not affected.
         :param envs: The environment variables which always bypasses the jail policy.
         :param resources: The resource specification. (TODO: details)
@@ -391,7 +391,7 @@ class ComputeSession(BaseFunction):
             Key and value of this map should be vfolder name and custom path.
             Defalut mounts or relative paths are under /home/work.
             If you want different paths, names should be absolute paths.
-            vFolders should have different name from linux system folders.
+            The target mount path of vFolders should not overlap with the linux system folders.
             vFolders which has a dot(.) prefix in its name are not affected.
         :param envs: The environment variables which always bypasses the jail policy.
         :param resources: The resource specification. (TODO: details)


### PR DESCRIPTION
Resolve: lablup/backend.ai#329

User help text is edited about arbitrary path using. Default path and relative path are /home/work, but users can use absolute path when they mount.

Funtions are not changed, because most of mounting functions are in manager/agent.