### PR TITLE
feat: Use bgtask API to track progress of vfolder clone asynchronously

### DIFF
--- a/changes/205.fix
+++ b/changes/205.fix
@@ -1,0 +1,1 @@
+Split the destination vfolder creation and actual clone operationsrun the clone operation as a background task and just return the bgtask ID in the vfolder clone API, so that clients could keep track of the progress and result

--- a/changes/205.fix
+++ b/changes/205.fix
@@ -1,1 +1,1 @@
-Split the destination vfolder creation and actual clone operationsrun the clone operation as a background task and just return the bgtask ID in the vfolder clone API, so that clients could keep track of the progress and result
+Use the bgtask APIs to track progress of vfolder clone operation if available.

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -10,12 +10,13 @@ from tqdm import tqdm
 
 from ai.backend.client.config import DEFAULT_CHUNK_SIZE
 from ai.backend.client.session import Session
+
+from ..compat import asyncio_run
 from ..session import AsyncSession
 from .main import main
 from .interaction import ask_yn
 from .pretty import print_done, print_error, print_fail, print_info, print_wait, print_warn
 from .params import ByteSizeParamType, ByteSizeParamCheckType
-from ..compat import asyncio_run
 
 
 @main.group()

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -579,7 +579,7 @@ def clone(name, target_name, target_host, usage_mode, permission):
                 completion_msg_func = lambda: print_done("VFolder cloned.")
                 async with bgtask.listen_events() as response:
                     # TODO: get the unit of progress from response
-                    with tqdm(unit='bytes', disabled=True) as pbar:
+                    with tqdm(unit='bytes', disable=True) as pbar:
                         async for ev in response:
                             data = json.loads(ev.data)
                             if ev.event == 'bgtask_updated':

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -568,14 +568,14 @@ def clone(name, target_name, target_host, usage_mode, permission):
                 permission=permission,
             )
             bgtask_id = result['bgtask_id']
-            bgtask = session.BackgroundTask(bgtask_id)
         except Exception as e:
             print_error(e)
             sys.exit(1)
 
-    async def clone_vfolder_tracker():
+    async def clone_vfolder_tracker(bgtask_id):
         async with AsyncSession() as session:
             try:
+                bgtask = session.BackgroundTask(bgtask_id)
                 completion_msg_func = lambda: print_done("Vfolder cloned.")
                 with tqdm(unit='bytes') as pbar:
                     async with bgtask.listen_events() as response:
@@ -595,8 +595,9 @@ def clone(name, target_name, target_host, usage_mode, permission):
                                                     "cancelled in the middle.")
             finally:
                 completion_msg_func()
-    
-    asyncio_run(clone_vfolder_tracker())
+
+
+    asyncio_run(clone_vfolder_tracker(bgtask_id))
 
 @vfolder.command()
 @click.argument('name', type=str)

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -573,10 +573,14 @@ def clone(name, target_name, target_host, usage_mode, permission):
             sys.exit(1)
 
     async def clone_vfolder_tracker(bgtask_id):
+        print_wait(
+            "Cloning the vfolder... "
+            "(This may take a while depending on its size and number of files!)",
+        )
         async with AsyncSession() as session:
             try:
                 bgtask = session.BackgroundTask(bgtask_id)
-                completion_msg_func = lambda: print_done("VFolder cloned.")
+                completion_msg_func = lambda: print_done("Cloning the vfolder is complete.")
                 async with bgtask.listen_events() as response:
                     # TODO: get the unit of progress from response
                     with tqdm(unit='bytes', disable=True) as pbar:
@@ -589,16 +593,20 @@ def clone(name, target_name, target_host, usage_mode, permission):
                             elif ev.event == 'bgtask_failed':
                                 error_msg = data['message']
                                 completion_msg_func = \
-                                    lambda: print_fail(f"Error occurred: {error_msg}")
+                                    lambda: print_fail(
+                                        f"Error during the operation: {error_msg}",
+                                    )
                             elif ev.event == 'bgtask_cancelled':
                                 completion_msg_func = \
-                                    lambda: print_warn("Vfolder cloning has been "
-                                                       "cancelled in the middle.")
+                                    lambda: print_warn(
+                                        "The operation has been cancelled in the middle. "
+                                        "(This may be due to server shutdown.)",
+                                    )
             finally:
                 completion_msg_func()
 
     if bgtask_id is None:
-        print_done("VFolder cloned.")
+        print_done("Cloning the vfolder is complete.")
     else:
         asyncio_run(clone_vfolder_tracker(bgtask_id))
 

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -596,8 +596,8 @@ def clone(name, target_name, target_host, usage_mode, permission):
             finally:
                 completion_msg_func()
 
-
     asyncio_run(clone_vfolder_tracker(bgtask_id))
+
 
 @vfolder.command()
 @click.argument('name', type=str)

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -579,7 +579,7 @@ def clone(name, target_name, target_host, usage_mode, permission):
                 completion_msg_func = lambda: print_done("VFolder cloned.")
                 async with bgtask.listen_events() as response:
                     # TODO: get the unit of progress from response
-                    with tqdm(unit='bytes') as pbar:
+                    with tqdm(unit='bytes', disabled=True) as pbar:
                         async for ev in response:
                             data = json.loads(ev.data)
                             if ev.event == 'bgtask_updated':

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -2,11 +2,11 @@ from datetime import datetime
 import json
 from pathlib import Path
 import sys
-from tqdm import tqdm
 
 import click
 import humanize
 from tabulate import tabulate
+from tqdm import tqdm
 
 from ai.backend.client.config import DEFAULT_CHUNK_SIZE
 from ai.backend.client.session import Session
@@ -559,7 +559,7 @@ def clone(name, target_name, target_host, usage_mode, permission):
             vfolder_info = session.VFolder(name).info()
             if not vfolder_info['cloneable']:
                 print("Clone is not allowed for this virtual folder. "
-                    "Please update the 'cloneable' option.")
+                      "Please update the 'cloneable' option.")
                 return
             result = session.VFolder(name).clone(
                 target_name,
@@ -576,7 +576,7 @@ def clone(name, target_name, target_host, usage_mode, permission):
         async with AsyncSession() as session:
             try:
                 bgtask = session.BackgroundTask(bgtask_id)
-                completion_msg_func = lambda: print_done("Vfolder cloned.")
+                completion_msg_func = lambda: print_done("VFolder cloned.")
                 with tqdm(unit='bytes') as pbar:
                     async with bgtask.listen_events() as response:
                         async for ev in response:
@@ -592,7 +592,7 @@ def clone(name, target_name, target_host, usage_mode, permission):
                             elif ev.event == 'bgtask_cancelled':
                                 completion_msg_func = \
                                     lambda: print_warn("Vfolder cloning has been "
-                                                    "cancelled in the middle.")
+                                                       "cancelled in the middle.")
             finally:
                 completion_msg_func()
 

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -577,8 +577,9 @@ def clone(name, target_name, target_host, usage_mode, permission):
             try:
                 bgtask = session.BackgroundTask(bgtask_id)
                 completion_msg_func = lambda: print_done("VFolder cloned.")
-                with tqdm(unit='bytes') as pbar:
-                    async with bgtask.listen_events() as response:
+                async with bgtask.listen_events() as response:
+                    # TODO: get the unit of progress from response
+                    with tqdm(unit='bytes') as pbar:
                         async for ev in response:
                             data = json.loads(ev.data)
                             if ev.event == 'bgtask_updated':

--- a/src/ai/backend/client/cli/vfolder.py
+++ b/src/ai/backend/client/cli/vfolder.py
@@ -567,7 +567,7 @@ def clone(name, target_name, target_host, usage_mode, permission):
                 usage_mode=usage_mode,
                 permission=permission,
             )
-            bgtask_id = result['bgtask_id']
+            bgtask_id = result.get('bgtask_id')
         except Exception as e:
             print_error(e)
             sys.exit(1)
@@ -597,7 +597,10 @@ def clone(name, target_name, target_host, usage_mode, permission):
             finally:
                 completion_msg_func()
 
-    asyncio_run(clone_vfolder_tracker(bgtask_id))
+    if bgtask_id is None:
+        print_done("VFolder cloned.")
+    else:
+        asyncio_run(clone_vfolder_tracker(bgtask_id))
 
 
 @vfolder.command()


### PR DESCRIPTION
resolved : https://github.com/lablup/backend.ai/issues/354

**prevent blocking of the whole manager while cloning a vfolder**
- **Run the clone operation as a background task and just return the bgtask ID in the vfolder clone API, so that clients could keep track of the progress and result.**
![clone pr](https://user-images.githubusercontent.com/18081105/154634891-a2a2bbf1-554b-4bea-8446-c9156b5cc812.png)

- **Split the destination vfolder creation and actual clone operations, and insert the database transaction to create the destination vfolder record between them.**
![split](https://user-images.githubusercontent.com/18081105/154635456-ed1052ad-6bb3-410a-b94d-044c79f4b85b.png)

