### PR TITLE
feat: update image func about architecture

### DIFF
--- a/src/ai/backend/client/cli/admin/image.py
+++ b/src/ai/backend/client/cli/admin/image.py
@@ -89,11 +89,12 @@ def rescan(registry: str) -> None:
 @image.command()
 @click.argument('alias', type=str)
 @click.argument('target', type=str)
-def alias(alias, target):
+@click.argument('architecture', type=str, default='x86_64')
+def alias(alias, target, architecture):
     """Add an image alias."""
     with Session() as session:
         try:
-            result = session.Image.alias_image(alias, target)
+            result = session.Image.alias_image(alias, target, architecture)
         except Exception as e:
             print_error(e)
             sys.exit(1)

--- a/src/ai/backend/client/func/image.py
+++ b/src/ai/backend/client/func/image.py
@@ -14,6 +14,7 @@ _default_list_fields_admin = (
     image_fields['name'],
     image_fields['registry'],
     image_fields['tag'],
+    image_fields['architecture'],
     image_fields['digest'],
     image_fields['size_bytes'],
     image_fields['aliases'],
@@ -65,7 +66,7 @@ class Image(BaseFunction):
 
     @api_function
     @classmethod
-    async def alias_image(cls, alias: str, target: str) -> dict:
+    async def alias_image(cls, alias: str, target: str, architecture: str) -> dict:
         q = 'mutation($alias: String!, $target: String!) {' \
             '  alias_image(alias: $alias, target: $target) {' \
             '   ok msg' \
@@ -74,6 +75,7 @@ class Image(BaseFunction):
         variables = {
             'alias': alias,
             'target': target,
+            'architecture': architecture,
         }
         data = await api_session.get().Admin._query(q, variables)
         return data['alias_image']

--- a/src/ai/backend/client/output/fields.py
+++ b/src/ai/backend/client/output/fields.py
@@ -90,6 +90,7 @@ image_fields = FieldSet([
     FieldSpec('name'),
     FieldSpec('registry'),
     FieldSpec('tag'),
+    FieldSpec('architecture'),
     FieldSpec('digest'),
     FieldSpec('size_bytes', formatter=sizebytes_output_formatter),
     FieldSpec('aliases'),


### PR DESCRIPTION
According to multi-architecture supporting in manager in https://github.com/lablup/backend.ai-manager/pull/543, update image functions to show and input architecture info