### PR TITLE
fix: Deprecate concurrency_limit (replaced with max_concurrent_sessions)

### DIFF
--- a/changes/215.fix.md
+++ b/changes/215.fix.md
@@ -1,0 +1,1 @@
+Remove remaining traces of `keypair.concurrency_limit` which has been replaced with `keypair_resource_policy.max_concurrenct_sessions`

--- a/src/ai/backend/client/cli/admin/keypair.py
+++ b/src/ai/backend/client/cli/admin/keypair.py
@@ -32,7 +32,6 @@ def info(ctx: CLIContext) -> None:
         keypair_fields['last_used'],
         keypair_fields['resource_policy'],
         keypair_fields['rate_limit'],
-        keypair_fields['concurrency_limit'],
         keypair_fields['concurrency_used'],
     ]
     with Session() as session:
@@ -77,7 +76,6 @@ def list(ctx: CLIContext, user_id, is_active, filter_, order, offset, limit) -> 
         keypair_fields['last_used'],
         keypair_fields['resource_policy'],
         keypair_fields['rate_limit'],
-        keypair_fields['concurrency_limit'],
         keypair_fields['concurrency_used'],
     ]
     try:

--- a/src/ai/backend/client/output/fields.py
+++ b/src/ai/backend/client/output/fields.py
@@ -111,7 +111,6 @@ keypair_fields = FieldSet([
     FieldSpec('last_used'),
     FieldSpec('resource_policy'),
     FieldSpec('rate_limit'),
-    FieldSpec('concurrency_limit'),
     FieldSpec('concurrency_used'),
     FieldSpec('ssh_public_key'),
     FieldSpec('ssh_private_key'),
@@ -124,7 +123,7 @@ keypair_resource_policy_fields = FieldSet([
     FieldSpec('name'),
     FieldSpec('created_at'),
     FieldSpec('total_resource_slots'),
-    FieldSpec('max_concurrent_sessions'),
+    FieldSpec('max_concurrent_sessions'),  # formerly concurrency_limit
     FieldSpec('max_vfolder_count'),
     FieldSpec('max_vfolder_size', formatter=sizebytes_output_formatter),
     FieldSpec('idle_timeout'),

--- a/src/ai/backend/client/output/types.py
+++ b/src/ai/backend/client/output/types.py
@@ -25,7 +25,6 @@ _predefined_humanized_field_names = {
     "group_id": "Group ID",
     "user_id": "User ID",
     "resource_policy": "Res.Policy",
-    "concurrency_limit": "Concur.Limit",
     "concurrency_used": "Concur.Used",
     "fsprefix": "FS Prefix",
     "hardware_metadata": "HW Metadata",


### PR DESCRIPTION
In line with lablup/backend.ai#365