### PR TITLE
fix: remove invalid "uuid" field from groups model

### DIFF
--- a/changes/216.fix
+++ b/changes/216.fix
@@ -1,0 +1,1 @@
+Remove invalid "uuid" field from `groups` model.

--- a/src/ai/backend/client/func/group.py
+++ b/src/ai/backend/client/func/group.py
@@ -136,7 +136,7 @@ class Group(BaseFunction):
         You need an admin privilege for this operation.
         """
         if fields is None:
-            fields = ('id', 'domain_name', 'name', 'uuid')
+            fields = ('id', 'domain_name', 'name')
         query = textwrap.dedent("""\
             mutation($name: String!, $input: GroupInput!) {
                 create_group(name: $name, props: $input) {


### PR DESCRIPTION
There is no such field `uuid` in manager's `groups` model. This raises `'Cannot query field "uuid" on type "Group". Did you mean "id"?'` error when creating a group (project) when `fields` parameter is not specified.