### PR TITLE
fix: remove access key option in vfolder list

### DIFF
--- a/changes/218.fix
+++ b/changes/218.fix
@@ -1,0 +1,1 @@
+Remove access key option in vfolder list command since manager does not support the field.

--- a/src/ai/backend/client/cli/admin/vfolder.py
+++ b/src/ai/backend/client/cli/admin/vfolder.py
@@ -24,9 +24,6 @@ def vfolder() -> None:
 def _list_cmd(docs: str = None):
 
     @click.pass_obj
-    @click.option('--access-key', type=str, default=None,
-                help='Get vfolders for the given access key '
-                    '(only works if you are a super-admin)')
     @click.option('-g', '--group', type=str, default=None,
                 help='Filter by group ID.')
     @click.option('--filter', 'filter_', default=None,
@@ -37,14 +34,14 @@ def _list_cmd(docs: str = None):
                 help='The index of the current page start for pagination.')
     @click.option('--limit', default=None,
                 help='The page size for pagination.')
-    def list(ctx: CLIContext, access_key, group, filter_, order, offset, limit) -> None:
+    def list(ctx: CLIContext, group, filter_, order, offset, limit) -> None:
         """
         List virtual folders.
         """
         try:
             with Session() as session:
                 fetch_func = lambda pg_offset, pg_size: session.VFolder.paginated_list(
-                    group, access_key,
+                    group,
                     fields=_default_list_fields,
                     page_offset=pg_offset,
                     page_size=pg_size,

--- a/src/ai/backend/client/func/vfolder.py
+++ b/src/ai/backend/client/func/vfolder.py
@@ -91,7 +91,6 @@ class VFolder(BaseFunction):
     async def paginated_list(
         cls,
         group: str = None,
-        access_key: str = None,
         *,
         fields: Sequence[FieldSpec] = _default_list_fields,
         page_offset: int = 0,
@@ -109,7 +108,6 @@ class VFolder(BaseFunction):
             'vfolder_list',
             {
                 'group_id': (group, 'UUID'),
-                'access_key': (access_key, 'String'),
                 'filter': (filter, 'String'),
                 'order': (order, 'String'),
             },


### PR DESCRIPTION
Since vfolder_list resolver method does not support access key field, remove access_key option in `admin vfolder list` command.

1. No access_key parameter at resolver method. https://github.com/lablup/backend.ai-manager/blob/main/src/ai/backend/manager/models/gql.py#L1073-#L1104
2. Manager already filters query by user email.  https://github.com/lablup/backend.ai-manager/blob/main/src/ai/backend/manager/api/vfolder.py#L426