### PR TITLE
fix: remove deprecated arg at asyncio.gather

### DIFF
--- a/changes/220.fix
+++ b/changes/220.fix
@@ -1,1 +1,1 @@
-remove the deprecated argument loop at asyncio.gather.
+Remove the deprecated loop argument from a call to `asyncio.gather()`

--- a/changes/220.fix
+++ b/changes/220.fix
@@ -1,0 +1,1 @@
+remove the deprecated argument loop at asyncio.gather.

--- a/src/ai/backend/client/compat.py
+++ b/src/ai/backend/client/compat.py
@@ -31,7 +31,7 @@ def _cancel_all_tasks(loop):
     for task in to_cancel:
         task.cancel()
     loop.run_until_complete(
-        asyncio.gather(*to_cancel, loop=loop, return_exceptions=True))
+        asyncio.gather(*to_cancel, return_exceptions=True))
     for task in to_cancel:
         if task.cancelled():
             continue


### PR DESCRIPTION
remove the deprecated argument loop at asyncio.gather since the loop parameter has been removed from Python 3.10 https://docs.python.org/ko/3/library/asyncio-task.html#asyncio.gather