### PR TITLE
feat: Add `backend.ai session watch` command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ install_requires = [
     'click>=8.0.1',
     'colorama>=0.4.4',
     'humanize>=3.1.0',
+    'inquirer~=2.9.2',
     'janus>=0.6.1',
     'multidict>=5.1.0',
     'python-dateutil>=2.8.2',

--- a/src/ai/backend/client/cli/session.py
+++ b/src/ai/backend/client/cli/session.py
@@ -954,14 +954,20 @@ def _watch_cmd(docs: Optional[str] = None):
                 async with compute_session.listen_events(scope=scope) as response:  # AsyncSession
                     async for ev in response:
                         nonlocal current_state_idx
-                        current_state_idx = states.index(ev.event)
+
+                        if ev.event != 'kernel_cancelled':
+                            current_state_idx = states.index(ev.event)
+
                         print_state(session_name_or_id, current_state_idx)
 
-                        if ev.event == states[-1]:
+                        if ev.event == 'kernel_cancelled':
+                            click.echo(click.style('\u2718 ', fg='red') + 'kernel_cancelled')
                             break
 
-                current_state_idx = len(states)
-                print_state(session_name_or_id, current_state_idx)
+                        if ev.event == states[-1]:
+                            current_state_idx = len(states)
+                            print_state(session_name_or_id, current_state_idx)
+                            break
 
         try:
             asyncio_run(_run_events())

--- a/src/ai/backend/client/cli/session.py
+++ b/src/ai/backend/client/cli/session.py
@@ -956,7 +956,10 @@ def _watch_cmd(docs: Optional[str] = None):
                         nonlocal current_state_idx
 
                         if ev.event != 'kernel_cancelled':
-                            current_state_idx = states.index(ev.event)
+                            try:
+                                current_state_idx = states.index(ev.event)
+                            except ValueError:
+                                pass
 
                         print_state(session_name_or_id, current_state_idx)
 
@@ -973,6 +976,7 @@ def _watch_cmd(docs: Optional[str] = None):
             asyncio_run(_run_events())
         except Exception as e:
             print_error(e)
+            return 1
 
         return 0
 

--- a/src/ai/backend/client/cli/session.py
+++ b/src/ai/backend/client/cli/session.py
@@ -924,6 +924,7 @@ def _watch_cmd(docs: Optional[str] = None):
         session_name_or_id = inquirer.prompt(questions).get('session')
 
         states = [
+            'kernel_creating',
             'kernel_started',
             'session_started',
             'kernel_terminating',
@@ -937,11 +938,11 @@ def _watch_cmd(docs: Optional[str] = None):
             click.echo(click.style(f'session name: {session_name_or_id}', fg='cyan'))
             for i, state in enumerate(states):
                 if i < current_state_idx:
-                    click.echo(click.style(f'\u2714 {state}', fg='green'))
+                    click.echo(click.style('\u2714 ', fg='green') + state)
                 elif i == current_state_idx:
-                    click.echo(click.style(f'\u2219 {state}', bold=True))
+                    click.echo(click.style(f'\u22EF {state}', bold=True))
                 else:
-                    click.echo(f'\u22EF {state}')
+                    click.echo(click.style('\u2219 ', fg='yellow') + state)
 
         async def _run_events():
             async with AsyncSession() as session:
@@ -950,7 +951,7 @@ def _watch_cmd(docs: Optional[str] = None):
                     compute_session = session.ComputeSession.from_session_id(session_id)
                 except ValueError:
                     compute_session = session.ComputeSession(session_name_or_id, owner_access_key)
-                async with compute_session.listen_events(scope=scope) as response:
+                async with compute_session.listen_events(scope=scope) as response:  # AsyncSession
                     async for ev in response:
                         nonlocal current_state_idx
                         current_state_idx = states.index(ev.event)

--- a/src/ai/backend/client/cli/session.py
+++ b/src/ai/backend/client/cli/session.py
@@ -929,7 +929,7 @@ def _watch_cmd(docs: Optional[str] = None):
             'session_started',
             'kernel_terminating',
             'kernel_terminated',
-            'session_terminated'
+            'session_terminated',
         ]
         current_state_idx = -1
 

--- a/src/ai/backend/client/cli/session.py
+++ b/src/ai/backend/client/cli/session.py
@@ -118,7 +118,7 @@ def _create_cmd(docs: str = None):
         starts_at: str | None,
         startup_command: str | None,
         enqueue_only: bool,
-        max_wait: bool,
+        max_wait: int,
         no_reuse: bool,
         depends: Sequence[str],
         callback_url: str,

--- a/src/ai/backend/client/cli/session.py
+++ b/src/ai/backend/client/cli/session.py
@@ -978,11 +978,10 @@ def _watch_cmd(docs: Optional[str] = None):
 
         async def _run_events_with_timeout(timeout: int):
             assert timeout > 0
-            # FIXME: DeprecationWarning: The explicit passing of coroutine objects to asyncio.wait() is deprecated since Python 3.8, and scheduled for removal in Python 3.11.
-            done, pending = await asyncio.wait([
-                _run_events(),
-                asyncio.sleep(timeout),
-            ], return_when=asyncio.FIRST_COMPLETED)
+            done, pending = await asyncio.wait({
+                asyncio.create_task(_run_events()),
+                asyncio.create_task(asyncio.sleep(timeout)),
+            }, return_when=asyncio.FIRST_COMPLETED)
             for task in pending:
                 task.cancel()
                 with suppress(asyncio.CancelledError):


### PR DESCRIPTION
This PR implements a `backend.ai session watch` command, or `backend.ai watch` in short, to track and display the event stream of target session.

How to use:
- `backend.ai watch [SESSION_ID]`
- `backend.ai session watch [SESSION_ID]`

<img width="364" alt="image" src="https://user-images.githubusercontent.com/14137676/170644536-ab5ec88f-2ff9-4bd5-951e-47d4a68a9d6e.png">

There are some limitaions:
- It cannot know in which state the session is until it receives the first event.
- It does not check whether the output device is tty or not.

Refs
- lablup/backend.ai#395